### PR TITLE
Hardcoded support for boolean converter

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileValidator.java
@@ -208,19 +208,32 @@ class MicroProfileValidator {
 			}
 		}
 
-		if ((metadata.isIntegerType() && !isIntegerString(value)) || (metadata.isFloatType() && !isFloatString(value))
-				|| (metadata.isBooleanType() && !isBooleanString(value))
+		if (metadata.isBooleanType() && !isBooleanString(value)) {
+			return "Type mismatch: " + metadata.getType() + " expected. By default, this value will be interpreted as 'false'";
+		}
+
+		if ((metadata.isIntegerType() && !isIntegerString(value)
+				|| (metadata.isFloatType() && !isFloatString(value))
 				|| (metadata.isDoubleType() && !isDoubleString(value))
 				|| (metadata.isLongType() && !isLongString(value)) || (metadata.isShortType() && !isShortString(value))
 				|| (metadata.isBigDecimalType() && !isBigDecimalString(value))
-				|| (metadata.isBigIntegerType() && !isBigIntegerString(value))) {
+				|| (metadata.isBigIntegerType() && !isBigIntegerString(value)))) {
 			return "Type mismatch: " + metadata.getType() + " expected";
 		}
 		return null;
 	}
 
 	private static boolean isBooleanString(String str) {
-		return "true".equals(str) || "false".equals(str);
+		if (str == null) {
+			return false;
+		}
+		String strUpper = str.toUpperCase();
+		return "TRUE".equals(strUpper)
+				|| "FALSE".equals(strUpper)
+				|| "Y".equals(strUpper)
+				|| "YES".equals(strUpper)
+				|| "1".equals(strUpper)
+				|| "ON".equals(strUpper);
 	}
 
 	private static boolean isIntegerString(String str) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCodeActionsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCodeActionsTest.java
@@ -205,7 +205,7 @@ public class ApplicationPropertiesCodeActionsTest {
 	@Test
 	public void codeActionsForUnknownBoolean() throws BadLocationException {
 		String value = "quarkus.http.cors=fals";
-		Diagnostic d = d(0, 18, 22, "Type mismatch: boolean expected", DiagnosticSeverity.Error, ValidationType.value);
+		Diagnostic d = d(0, 18, 22, "Type mismatch: boolean expected. By default, this value will be interpreted as 'false'", DiagnosticSeverity.Error, ValidationType.value);
 
 		testDiagnosticsFor(value, d);
 		testCodeActionsFor(value, d, ca("Did you mean 'false'?", te(0, 18, 0, 22, "false"), d));

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDiagnosticsTest.java
@@ -414,7 +414,11 @@ public class ApplicationPropertiesDiagnosticsTest {
 	public void validateBooleanNoError() throws BadLocationException {
 
 		String value = "quarkus.http.cors  =   \n" + //
-				"quarkus.arc.auto-inject-fields=false\n" + //
+				"quarkus.arc.auto-inject-fields=falSE\n" + //
+				"quarkus.arc.remove-final-for-proxyable-methods = YeS\n" + //
+				"quarkus.banner.enabled = ON\n" + //
+				"quarkus.datasource.health.enabled=Y\n" + //
+				"quarkus.datasource.jdbc.detect-statement-leaks=1\n" + //
 				"quarkus.ssl.native = true\n" + //
 				"MP_Fault_Tolerance_Metrics_Enabled=false";
 
@@ -432,11 +436,11 @@ public class ApplicationPropertiesDiagnosticsTest {
 
 		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
 		testDiagnosticsFor(value, getDefaultMicroProfileProjectInfo(), settings,
-				d(0, 23, 30, "Type mismatch: boolean expected", DiagnosticSeverity.Error, ValidationType.value),
-				d(1, 31, 35, "Type mismatch: boolean expected", DiagnosticSeverity.Error, ValidationType.value),
-				d(2, 21, 26, "Type mismatch: java.util.Optional<java.lang.Boolean> expected", DiagnosticSeverity.Error,
+				d(0, 23, 30, "Type mismatch: boolean expected. By default, this value will be interpreted as 'false'", DiagnosticSeverity.Error, ValidationType.value),
+				d(1, 31, 35, "Type mismatch: boolean expected. By default, this value will be interpreted as 'false'", DiagnosticSeverity.Error, ValidationType.value),
+				d(2, 21, 26, "Type mismatch: java.util.Optional<java.lang.Boolean> expected. By default, this value will be interpreted as 'false'", DiagnosticSeverity.Error,
 						ValidationType.value),
-				d(3, 35, 38, "Type mismatch: java.lang.Boolean expected", DiagnosticSeverity.Error,
+				d(3, 35, 38, "Type mismatch: java.lang.Boolean expected. By default, this value will be interpreted as 'false'", DiagnosticSeverity.Error,
 						ValidationType.value));
 	}
 


### PR DESCRIPTION
Boolean validator now supports 'Y', 'YES', '1', 'ON'. The error message for an invalid boolean value now displays a warning that the value will be automatically interpreted as 'false'.

Closes https://github.com/redhat-developer/quarkus-ls/issues/298

Signed-off-by: David Thompson <davthomp@redhat.com>