### PR TITLE
Property expression definition

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/PropertyValueExpression.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/PropertyValueExpression.java
@@ -70,4 +70,34 @@ public class PropertyValueExpression extends Node {
 		return text.charAt(text.length() - 1) == '}';
 	}
 
+	/**
+	 * Returns the offset of the start of the referenced property name,
+	 * or the offset after the `$` if no property is referenced.
+	 * 
+	 * @return the offset of the start of the referenced property name,
+	 * or the offset after the `$` if no property is referenced.
+	 */
+	public int getReferenceStartOffset() {
+		String propName = getReferencedPropertyName();
+		if (propName == null) {
+			return getStart() + 1;
+		}
+		return getStart() + getText().indexOf(propName);
+	}
+
+	/**
+	 * Returns the offset of the end of the referenced property name,
+	 * or the offset after the `$` if no property is referenced.
+	 * 
+	 * @return the offset of the end of the referenced property name,
+	 * or the offset after the `$` if no property is referenced.
+	 */
+	public int getReferenceEndOffset() {
+		String propName = getReferencedPropertyName();
+		if (propName == null) {
+			return getStart() + 1;
+		}
+		return getStart() + getText().indexOf(propName) + propName.length();
+	}
+
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileDefinition.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileDefinition.java
@@ -13,16 +13,16 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.services;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertyDefinitionParams;
 import org.eclipse.lsp4mp.commons.metadata.ItemHint;
@@ -36,6 +36,7 @@ import org.eclipse.lsp4mp.model.PropertiesModel;
 import org.eclipse.lsp4mp.model.Property;
 import org.eclipse.lsp4mp.model.PropertyKey;
 import org.eclipse.lsp4mp.model.PropertyValue;
+import org.eclipse.lsp4mp.model.PropertyValueExpression;
 import org.eclipse.lsp4mp.utils.MicroProfilePropertiesUtils;
 import org.eclipse.lsp4mp.utils.PositionUtils;
 
@@ -51,78 +52,111 @@ public class MicroProfileDefinition {
 
 	/**
 	 * Returns as promise the Java field definition location of the property at the
-	 * given <code>position</code> of the given application.properties
+	 * given <code>position</code> of the given microprofile-config.properties
 	 * <code>document</code>.
 	 *
-	 * @param document              the properties model.
-	 * @param position              the position where definition was triggered
-	 * @param projectInfo           the MicroProfile project info
-	 * @param provider              the MicroProfile property definition provider.
-	 * @param definitionLinkSupport true if {@link LocationLink} must be returned
-	 *                              and false otherwise.
+	 * @param document    the properties model.
+	 * @param position    the position where definition was triggered
+	 * @param projectInfo the MicroProfile project info
+	 * @param provider    the MicroProfile property definition provider.
 	 * @return as promise the Java field definition location of the property at the
-	 *         given <code>position</code> of the given application.properties
-	 *         <code>document</code>.
+	 *         given <code>position</code> of the given
+	 *         microprofile-config.properties <code>document</code>.
 	 */
-	public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> findDefinition(
-			PropertiesModel document, Position position, MicroProfileProjectInfo projectInfo,
-			MicroProfilePropertyDefinitionProvider provider, boolean definitionLinkSupport) {
+	public CompletableFuture<List<LocationLink>> findDefinition(PropertiesModel document, Position position,
+			MicroProfileProjectInfo projectInfo, MicroProfilePropertyDefinitionProvider provider) {
 
 		try {
 			Node node = document.findNodeAt(position);
 			if (node == null) {
-				return CompletableFuture.completedFuture(getEmptyDefinition(definitionLinkSupport));
+				return getEmptyDefinition();
+			}
+
+			if (node.getNodeType() == NodeType.PROPERTY_VALUE_EXPRESSION) {
+				return CompletableFuture.completedFuture(
+						findPropertyValueExpressionDefinition(document, (PropertyValueExpression) node));
 			}
 
 			// Get the property at the given position
 			PropertyKey key = getPropertyKey(node);
 
 			if (key == null) {
-				return CompletableFuture.completedFuture(getEmptyDefinition(definitionLinkSupport));
+				return getEmptyDefinition();
 			}
 
-			// Get metatada of the property
+			// Get metadata of the property
 			ItemMetadata item = MicroProfilePropertiesUtils.getProperty(key.getPropertyName(), projectInfo);
 			if (item == null) {
-				return CompletableFuture.completedFuture(getEmptyDefinition(definitionLinkSupport));
+				return getEmptyDefinition();
 			}
 
 			MicroProfilePropertyDefinitionParams definitionParams = getPropertyDefinitionParams(document, item,
 					projectInfo, node);
 			if (definitionParams == null) {
-				return CompletableFuture.completedFuture(getEmptyDefinition(definitionLinkSupport));
+				return getEmptyDefinition();
 			}
 			return provider.getPropertyDefinition(definitionParams).thenApply(target -> {
 				if (target == null) {
-					return getEmptyDefinition(definitionLinkSupport);
+					return Collections.emptyList();
 				}
-				if (definitionLinkSupport) {
-					// Use document link
-					LocationLink link = new LocationLink(target.getUri(), target.getRange(), target.getRange(),
-							PositionUtils.createRange(node));
-					return Either.forRight(Collections.singletonList(link));
-				}
-				// Use simple location
-				return Either.forLeft(Collections.singletonList(target));
+				LocationLink link = new LocationLink(target.getUri(), target.getRange(), target.getRange(),
+						PositionUtils.createRange(node));
+				return Collections.singletonList(link);
 			});
 
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "In MicroProfileDefinition, position error", e);
 		}
-		return CompletableFuture.completedFuture(getEmptyDefinition(definitionLinkSupport));
+		return getEmptyDefinition();
 	}
 
-	private static Either<List<? extends Location>, List<? extends LocationLink>> getEmptyDefinition(
-			boolean definitionLinkSupport) {
-		return definitionLinkSupport ? Either.forRight(Collections.emptyList())
-				: Either.forLeft(Collections.emptyList());
+	/**
+	 * Finds all locations where the property referenced by
+	 * <code>propertyExpression</code> is assigned a value, and returns them as a
+	 * list of <code>LocationLink</code>
+	 *
+	 * If the referenced property is not assigned a value in the properties file,
+	 * then a empty list is returned.
+	 *
+	 * @param document                the PropertiesModel of the
+	 *                                PropertyValueExpression
+	 * @param propertyValueExpression the PropertyValueExpression whose definition
+	 *                                is to be found
+	 * @return a list of LocationLinks to the lines where the property referenced by
+	 *         the property expression is assigned a value
+	 */
+	private static List<LocationLink> findPropertyValueExpressionDefinition(PropertiesModel document,
+			PropertyValueExpression propertyValueExpression) {
+
+		String propToResolveName = propertyValueExpression.getReferencedPropertyName();
+
+		List<Property> props = new ArrayList<>();
+
+		for (Node modelChild : document.getChildren()) {
+			if (modelChild.getNodeType() == NodeType.PROPERTY) {
+				Property property = (Property) modelChild;
+				if (property.getPropertyName().equals(propToResolveName)
+						|| property.getPropertyNameWithProfile().equals(propToResolveName)) {
+					props.add(property);
+				}
+			}
+		}
+
+		if (!props.isEmpty()) {
+			return getPropertyDefinition(document, propertyValueExpression, props);
+		}
+
+		return Collections.emptyList();
+	}
+
+	private static CompletableFuture<List<LocationLink>> getEmptyDefinition() {
+		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	private static MicroProfilePropertyDefinitionParams getPropertyDefinitionParams(PropertiesModel document,
 			ItemMetadata item, MicroProfileProjectInfo projectInfo, Node node) {
 
-		if (node.getNodeType() != NodeType.PROPERTY_KEY
-				&& node.getNodeType() != NodeType.PROPERTY_VALUE
+		if (node.getNodeType() != NodeType.PROPERTY_KEY && node.getNodeType() != NodeType.PROPERTY_VALUE
 				&& node.getNodeType() != NodeType.PROPERTY_VALUE_EXPRESSION
 				&& node.getNodeType() != NodeType.PROPERTY_VALUE_LITERAL) {
 			return null;
@@ -134,35 +168,35 @@ public class MicroProfileDefinition {
 		String sourceField = null;
 
 		switch (node.getNodeType()) {
-		case PROPERTY_KEY: {
-			sourceType = item.getSourceType();
-			sourceField = item.getSourceField();
-			break;
-		}
-		case PROPERTY_VALUE_EXPRESSION:
-		case PROPERTY_VALUE_LITERAL:
-			node = node.getParent(); // HACK:
-		case PROPERTY_VALUE: {
-			sourceType = item.getHintType();
-			sourceField = ((PropertyValue) node).getValue();
-			// for the case of property which uses kebab_case, we must get the real value of
-			// the Java enumeration
-			// Ex: for quarkus.datasource.transaction-isolation-level = read-uncommitted
-			// the real value of Java enumeration 'read-uncommitted' is 'READ_UNCOMMITTED'
-			ItemHint itemHint = projectInfo.getHint(sourceType);
-			if (itemHint != null) {
-				ValueHint realValue = itemHint.getValue(sourceField, item.getConverterKinds());
-				if (realValue != null) {
-					sourceField = realValue.getValue();
-					if (realValue.getSourceType() != null) {
-						sourceType = realValue.getSourceType();
+			case PROPERTY_KEY: {
+				sourceType = item.getSourceType();
+				sourceField = item.getSourceField();
+				break;
+			}
+			case PROPERTY_VALUE_EXPRESSION:
+			case PROPERTY_VALUE_LITERAL:
+				node = node.getParent(); // HACK:
+			case PROPERTY_VALUE: {
+				sourceType = item.getHintType();
+				sourceField = ((PropertyValue) node).getValue();
+				// for the case of property which uses kebab_case, we must get the real value of
+				// the Java enumeration
+				// Ex: for quarkus.datasource.transaction-isolation-level = read-uncommitted
+				// the real value of Java enumeration 'read-uncommitted' is 'READ_UNCOMMITTED'
+				ItemHint itemHint = projectInfo.getHint(sourceType);
+				if (itemHint != null) {
+					ValueHint realValue = itemHint.getValue(sourceField, item.getConverterKinds());
+					if (realValue != null) {
+						sourceField = realValue.getValue();
+						if (realValue.getSourceType() != null) {
+							sourceType = realValue.getSourceType();
+						}
 					}
 				}
+				break;
 			}
-			break;
-		}
-		default:
-			return null;
+			default:
+				return null;
 		}
 
 		// Find definition (class, field of class, method of class, enum) only when
@@ -180,20 +214,35 @@ public class MicroProfileDefinition {
 		return definitionParams;
 	}
 
+	private static List<LocationLink> getPropertyDefinition(PropertiesModel document,
+			PropertyValueExpression propertyValueExpression, List<Property> referencedProperties) {
+
+		List<LocationLink> locationLinks = new ArrayList<>();
+		for (Property referencedProperty : referencedProperties) {
+			Node key = referencedProperty.getKey();
+			Range referencedPropertyRange = PositionUtils.createRange(key);
+			Range propertyReferenceRange = PositionUtils.createRange(propertyValueExpression.getReferenceStartOffset(),
+					propertyValueExpression.getReferenceEndOffset(), referencedProperty.getDocument());
+			locationLinks.add(new LocationLink(document.getDocumentURI(), referencedPropertyRange,
+					referencedPropertyRange, propertyReferenceRange));
+		}
+		return locationLinks;
+	}
+
 	private static PropertyKey getPropertyKey(Node node) {
 		if (node == null) {
 			return null;
 		}
 		switch (node.getNodeType()) {
-		case PROPERTY_KEY:
-			return (PropertyKey) node;
-		case PROPERTY_VALUE:
-			return ((Property) node.getParent()).getKey();
-		case PROPERTY_VALUE_EXPRESSION:
-		case PROPERTY_VALUE_LITERAL:
-			return ((Property) node.getParent().getParent()).getKey();
-		default:
-			return null;
+			case PROPERTY_KEY:
+				return (PropertyKey) node;
+			case PROPERTY_VALUE:
+				return ((Property) node.getParent()).getKey();
+			case PROPERTY_VALUE_EXPRESSION:
+			case PROPERTY_VALUE_LITERAL:
+				return ((Property) node.getParent().getParent()).getKey();
+			default:
+				return null;
 		}
 	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileLanguageService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileLanguageService.java
@@ -15,6 +15,7 @@ package org.eclipse.lsp4mp.services;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
@@ -147,7 +148,17 @@ public class MicroProfileLanguageService {
 			PropertiesModel document, Position position, MicroProfileProjectInfo projectInfo,
 			MicroProfilePropertyDefinitionProvider provider, boolean definitionLinkSupport) {
 		updateProperties(projectInfo, document);
-		return definition.findDefinition(document, position, projectInfo, provider, definitionLinkSupport);
+		CompletableFuture<List<LocationLink>> definitionLocationLinks = definition.findDefinition(document, position, projectInfo, provider);
+		if (definitionLinkSupport) {
+			return definitionLocationLinks.thenApply((List<LocationLink> resolvedLinks) -> {
+				return Either.forRight(resolvedLinks);
+			});
+		}
+		return definitionLocationLinks.thenApply((List<LocationLink> resolvedLinks) -> {
+			return Either.forLeft(resolvedLinks.stream().map((link) -> {
+				return new Location(link.getTargetUri(), link.getTargetRange());
+			}).collect(Collectors.toList()));
+		});
 	}
 
 	/**

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
@@ -434,18 +434,24 @@ public class MicroProfileAssert {
 
 	public static void testDefinitionFor(String value, LocationLink... expected)
 			throws BadLocationException, InterruptedException, ExecutionException {
-		testDefinitionFor(value, getDefaultMicroProfileProjectInfo(),
+		testDefinitionFor(value, null, expected);
+	}
+
+	public static void testDefinitionFor(String value, String documentName, LocationLink... expected)
+			throws BadLocationException, InterruptedException, ExecutionException {
+		
+		testDefinitionFor(value, documentName, getDefaultMicroProfileProjectInfo(),
 				getDefaultMicroProfilePropertyDefinitionProvider(), expected);
 	}
 
-	public static void testDefinitionFor(String value, MicroProfileProjectInfo projectInfo,
+	public static void testDefinitionFor(String value, String documentName, MicroProfileProjectInfo projectInfo,
 			MicroProfilePropertyDefinitionProvider definitionProvider, LocationLink... expected)
 			throws BadLocationException, InterruptedException, ExecutionException {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 
 		MicroProfileLanguageService languageService = new MicroProfileLanguageService();
-		PropertiesModel document = parse(value, null);
+		PropertiesModel document = parse(value, documentName);
 		Position position = document.positionAt(offset);
 
 		Either<List<? extends Location>, List<? extends LocationLink>> actual = languageService


### PR DESCRIPTION
You can now trigger Go To Definition inside ${...}, and it will navigate to the location where the property value is assigned in the properties file.

Closes redhat-developer/quarkus-ls#333.

Signed-off-by: David Thompson <davthomp@redhat.com>