### PR TITLE
Escape special characters within LSP snippets

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/SnippetsBuilder.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/SnippetsBuilder.java
@@ -39,7 +39,7 @@ public class SnippetsBuilder {
 		snippets.append("${");
 		snippets.append(index);
 		snippets.append(":");
-		snippets.append(text);
+		snippets.append(escape(text));
 		snippets.append("}");
 	}
 
@@ -65,6 +65,10 @@ public class SnippetsBuilder {
 		}
 		snippets.append("|");
 		snippets.append("}");
+	}
+
+	private static String escape(String text) {
+		return text.replace("$", "\\$").replace("}", "\\}");
 	}
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCompletionTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCompletionTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.lsp4mp.services.MicroProfileAssert.r;
 import static org.eclipse.lsp4mp.services.MicroProfileAssert.testCompletionFor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
@@ -211,13 +212,13 @@ public class ApplicationPropertiesCompletionTest {
 
 		projectInfo.setProperties(properties);
 
-		testCompletionFor(value, false, null, 2, projectInfo, c("quarkus.http.cors", "quarkus.http.cors=", r(0, 0, 0)),
+		testCompletionFor(value, false, 2, projectInfo, c("quarkus.http.cors", "quarkus.http.cors=", r(0, 0, 0)),
 				c("quarkus.application.name", "quarkus.application.name=", r(0, 0, 0)));
 
 		value = "quarkus.http.cors=false\r\n" + //
 				"|";
 
-		testCompletionFor(value, false, null, 1, projectInfo,
+		testCompletionFor(value, false, 1, projectInfo,
 				c("quarkus.application.name", "quarkus.application.name=", r(1, 0, 0)));
 
 	}
@@ -240,7 +241,7 @@ public class ApplicationPropertiesCompletionTest {
 
 		projectInfo.setProperties(properties);
 
-		testCompletionFor(value, false, null, 1, projectInfo,
+		testCompletionFor(value, false, 1, projectInfo,
 				c("quarkus.http.cors", "%prod.quarkus.http.cors=", r(1, 0, 6)));
 	}
 
@@ -260,13 +261,13 @@ public class ApplicationPropertiesCompletionTest {
 
 		projectInfo.setProperties(properties);
 
-		testCompletionFor(value, false, null, 2, projectInfo, c("quarkus.http.cors", "quarkus.http.cors=", r(0, 0, 0)),
+		testCompletionFor(value, false, 2, projectInfo, c("quarkus.http.cors", "quarkus.http.cors=", r(0, 0, 0)),
 				c("quarkus.application.name", "quarkus.application.name=", r(0, 0, 0)));
 
 		value = "quarkus.http.cors=false\r\n" + //
 				"%dev.|";
 
-		testCompletionFor(value, false, null, 2, projectInfo,
+		testCompletionFor(value, false, 2, projectInfo,
 				c("quarkus.http.cors", "%dev.quarkus.http.cors=", r(1, 0, 5)),
 				c("quarkus.application.name", "%dev.quarkus.application.name=", r(1, 0, 5)));
 
@@ -274,7 +275,7 @@ public class ApplicationPropertiesCompletionTest {
 				"%dev.quarkus.application.name\r\n" + //
 				"%prod.|";
 
-		testCompletionFor(value, false, null, 2, projectInfo,
+		testCompletionFor(value, false, 2, projectInfo,
 				c("quarkus.http.cors", "%prod.quarkus.http.cors=", r(2, 0, 6)),
 				c("quarkus.application.name", "%prod.quarkus.application.name=", r(2, 0, 6)));
 
@@ -297,4 +298,42 @@ public class ApplicationPropertiesCompletionTest {
 				c("quarkus.http.cors", "quarkus.http.cors = ${1|false,true|}", r(0, 0, 0)));
 	}
 
+	@Test
+	public void completionDefaultValueContainsDollarSign() throws BadLocationException {
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		ItemMetadata metadata = new ItemMetadata();
+		metadata.setName("price.string");
+		metadata.setDefaultValue("Price: $10");
+		projectInfo.setProperties(Collections.singletonList(metadata));
+
+		String value = "|";
+		testCompletionFor(value, true, 1, projectInfo, c("price.string", "price.string=${0:Price: \\$10}", r(0, 0, 0)));
+		testCompletionFor(value, false, 1, projectInfo, c("price.string", "price.string=Price: $10", r(0, 0, 0)));
+	}
+
+	@Test
+	public void completionDefaultValueContainsBraces() throws BadLocationException {
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		ItemMetadata metadata = new ItemMetadata();
+		metadata.setName("price.string");
+		metadata.setDefaultValue("Price: {10}");
+		projectInfo.setProperties(Collections.singletonList(metadata));
+
+		String value = "|";
+		testCompletionFor(value, true, 1, projectInfo, c("price.string", "price.string=${0:Price: {10\\}}", r(0, 0, 0)));
+		testCompletionFor(value, false, 1, projectInfo, c("price.string", "price.string=Price: {10}", r(0, 0, 0)));
+	}
+
+	@Test
+	public void completionDefaultValueContainsDollarSignAndBraces() throws BadLocationException {
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		ItemMetadata metadata = new ItemMetadata();
+		metadata.setName("price.string");
+		metadata.setDefaultValue("Price: ${price}");
+		projectInfo.setProperties(Collections.singletonList(metadata));
+
+		String value = "|";
+		testCompletionFor(value, true, 1, projectInfo, c("price.string", "price.string=${0:Price: \\${price\\}}", r(0, 0, 0)));
+		testCompletionFor(value, false, 1, projectInfo, c("price.string", "price.string=Price: ${price}", r(0, 0, 0)));
+	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
@@ -135,9 +135,14 @@ public class MicroProfileAssert {
 				getDefaultMicroProfileProjectInfo(), expectedItems);
 	}
 
-	public static void testCompletionFor(String value, boolean snippetSupport, String fileURI, Integer expectedCount,
+	public static void testCompletionFor(String value, boolean snippetSupport, Integer expectedCount,
 			MicroProfileProjectInfo projectInfo, CompletionItem... expectedItems) throws BadLocationException {
 		testCompletionFor(value, snippetSupport, false, null, expectedCount, projectInfo, expectedItems);
+	}
+
+	public static void testCompletionFor(String value, boolean snippetSupport, String fileURI, Integer expectedCount,
+			MicroProfileProjectInfo projectInfo, CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(value, snippetSupport, false, fileURI, expectedCount, projectInfo, expectedItems);
 	}
 
 	public static void testCompletionFor(String value, boolean snippetSupport, boolean insertSpacing, String fileURI,


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/quarkus-ls/issues/351

The issue was happening because the `$` and `}` characters were not being escaped. This PR escapes special snippet characters for properties' default values.

To test that this PR is working properly, try completion with the `quarkus.container-image.group` property as explained in the original issue, or try completion with a config property containing `${` and `}`:

```
    @ConfigProperty(name = "greeting.message", defaultValue = "price: ${item.price}") 
    String message;
```

After properties completion, the default value should be completely highlighted:
![conatiner-image](https://user-images.githubusercontent.com/20326645/88575835-79d1c200-d012-11ea-826c-a13a871759f2.gif)

Signed-off-by: David Kwon <dakwon@redhat.com>