### PR TITLE
Add snippets for new MicroProfile Health checks

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
@@ -32,6 +32,8 @@ public class MicroProfileJavaSnippetRegistryLoader implements ISnippetRegistryLo
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-faulttolerance.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-health.json"),
+				SnippetContextForJava.TYPE_ADAPTER);
 	}
 
 	@Override

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-health.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-health.json
@@ -1,0 +1,54 @@
+{
+  "MicroProfile readiness check": {
+    "prefix": "mpreadiness",
+    "body": [
+      "package ${1:packagename};",
+      "",
+      "import org.eclipse.microprofile.health.HealthCheck;",
+      "import org.eclipse.microprofile.health.HealthCheckResponse;",
+      "import org.eclipse.microprofile.health.Readiness;",
+      "",
+      "import javax.enterprise.context.ApplicationScoped;",
+      "",
+      "@Readiness",
+      "@ApplicationScoped",
+      "public class ${TM_FILENAME_BASE} implements HealthCheck {",
+      "",
+      "\t@Override",
+      "\tpublic HealthCheckResponse call() {",
+      "\t\treturn HealthCheckResponse.named(${TM_FILENAME_BASE}.class.getSimpleName()).withData(\"ready\",true).up().build();",
+      "\t}",
+      "}"
+    ],
+    "context": {
+      "type": "org.eclipse.microprofile.health.Readiness"
+    },
+    "description": "MicroProfile Health readiness check"
+  },
+  "MicroProfile liveness check": {
+    "prefix": "mpliveness",
+    "body": [
+      "package ${1:packagename};",
+      "",
+      "import org.eclipse.microprofile.health.HealthCheck;",
+      "import org.eclipse.microprofile.health.HealthCheckResponse;",
+      "import org.eclipse.microprofile.health.Liveness;",
+      "",
+      "import javax.enterprise.context.ApplicationScoped;",
+      "",
+      "@Liveness",
+      "@ApplicationScoped",
+      "public class ${TM_FILENAME_BASE} implements HealthCheck {",
+      "",
+      "\t@Override",
+      "\tpublic HealthCheckResponse call() {",
+      "\t\treturn HealthCheckResponse.named(${TM_FILENAME_BASE}.class.getSimpleName()).withData(\"live\",true).up().build();",
+      "\t}",
+      "}"
+    ],
+    "context": {
+      "type": "org.eclipse.microprofile.health.Liveness"
+    },
+    "description": "MicroProfile Health liveness check"
+  }
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
@@ -96,6 +96,31 @@ public class JavaTextDocumentSnippetRegistryTest {
 		Assert.assertTrue("Project has org.eclipse.microprofile.faulttolerance.Fallback type", match2);
 	}
 
+	@Test
+	public void mpHealthSnippets() {
+		Optional<Snippet> readinessSnippet = findByPrefix("mpreadiness", registry);
+		Assert.assertTrue("Tests has mpreadiness Java snippets", readinessSnippet.isPresent());
+
+		ISnippetContext<?> readinessContext = readinessSnippet.get().getContext();
+		Assert.assertNotNull("mpreadiness snippet has context", readinessContext);
+		Assert.assertTrue("mpreadiness snippet context is Java context", readinessContext instanceof SnippetContextForJava);
+
+		ProjectLabelInfoEntry readinessProjectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
+		boolean match = ((SnippetContextForJava) readinessContext).isMatch(readinessProjectInfo);
+		Assert.assertFalse("Project has no org.eclipse.microprofile.health.Readiness type", match);
+
+		ProjectLabelInfoEntry readinessProjectInfo2 = new ProjectLabelInfoEntry("",
+				Arrays.asList("org.eclipse.microprofile.health.Readiness"));
+		boolean match2 = ((SnippetContextForJava) readinessContext).isMatch(readinessProjectInfo2);
+		Assert.assertTrue("Project has org.eclipse.microprofile.health.Readiness type", match2);
+
+		Optional<Snippet> livenessSnippet = findByPrefix("mpliveness", registry);
+		Assert.assertTrue("Tests has mpliveness Java snippets", livenessSnippet.isPresent());
+		
+		ISnippetContext<?> livenessContext = livenessSnippet.get().getContext();
+		Assert.assertNotNull("mpliveness snippet has context", livenessContext);
+	}
+
 	private static Optional<Snippet> findByPrefix(String prefix, SnippetRegistry registry) {
 		return registry.getSnippets().stream().filter(snippet -> snippet.getPrefixes().contains(prefix)).findFirst();
 	}


### PR DESCRIPTION
Closes #28 

Adds snippets for creating a new basic liveness / readiness check. 

For snippet prefix i used `mpreadiness` and `mpliveness` but am open to any suggestions :) 

![image](https://user-images.githubusercontent.com/16768710/88687081-cd511800-d0c5-11ea-8dc8-09379a2470d2.png)
Liveness
![image](https://user-images.githubusercontent.com/16768710/88689968-22daf400-d0c9-11ea-84b5-7a8ec0f5279c.png)
Readiness
![image](https://user-images.githubusercontent.com/16768710/88690158-57e74680-d0c9-11ea-9c99-9a7d5283055c.png)


Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>