### PR TITLE
Add jax-rs snippets

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
@@ -26,6 +26,8 @@ public class MicroProfileJavaSnippetRegistryLoader implements ISnippetRegistryLo
 
 	@Override
 	public void load(SnippetRegistry registry) throws IOException {
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("jax-rs.json"),
+				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-metrics.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-openapi.json"),

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/jax-rs.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/jax-rs.json
@@ -1,0 +1,41 @@
+{
+  "JAX-RS - new resource class": {
+    "prefix": "jaxrc",
+    "body": [
+      "package ${1:packagename};",
+      "",
+      "import javax.ws.rs.GET;",
+      "import javax.ws.rs.Path;",
+      "import javax.ws.rs.Produces;",
+      "import javax.ws.rs.core.MediaType;",
+      "",
+      "@Path(\"${2:/path}\")",
+      "public class ${TM_FILENAME_BASE} {",
+      "",
+      "\t@GET",
+      "\t@Produces(MediaType.TEXT_PLAIN)",
+      "\tpublic String ${3:methodname}() {",
+      "\t\treturn \"hello\";",
+      "\t}",
+      "}"
+    ],
+    "description": "JAX-RS REST resource class",
+    "context": {
+      "type": "javax.ws.rs.GET"
+    }
+  },
+  "JAX-RS - new resource method": {
+    "prefix": "jaxrm",
+    "body": [
+      "@GET",
+      "@Produces(MediaType.TEXT_PLAIN)",
+      "public String ${1:methodname}() {",
+      "\treturn \"hello\";",
+      "}"
+    ],
+    "description": "JAX-RS REST resource method",
+    "context": {
+      "type": "javax.ws.rs.GET"
+    }
+  }
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
@@ -40,6 +40,25 @@ public class JavaTextDocumentSnippetRegistryTest {
 	}
 
 	@Test
+	public void jaxrsSnippets() {
+		Optional<Snippet> jaxrsSnippet = findByPrefix("jaxrc", registry);
+		Assert.assertTrue("Tests has jaxrc Java snippets", jaxrsSnippet.isPresent());
+
+		ISnippetContext<?> context = jaxrsSnippet.get().getContext();
+		Assert.assertNotNull("jaxrc snippet has context", context);
+		Assert.assertTrue("jaxrc snippet context is Java context", context instanceof SnippetContextForJava);
+
+		ProjectLabelInfoEntry projectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
+		boolean match = ((SnippetContextForJava) context).isMatch(projectInfo);
+		Assert.assertFalse("Project has no javax.ws.rs.GET type", match);
+
+		ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("",
+				Arrays.asList("javax.ws.rs.GET"));
+		boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
+		Assert.assertTrue("Project has javax.ws.rs.GET type", match2);
+	}
+
+	@Test
 	public void mpMetricsSnippets() {
 		Optional<Snippet> metricSnippet = findByPrefix("@Metric", registry);
 		Assert.assertTrue("Tests has @Metric Java snippets", metricSnippet.isPresent());


### PR DESCRIPTION
Closes #31 

Adds snippets for jax-rs resource classes and methods

![image](https://user-images.githubusercontent.com/16768710/88835958-0069d900-d1a4-11ea-8c6b-cf7453c0e1d8.png)


Snippets were taken from here https://github.com/redhat-developer/quarkus-ls/blob/master/quarkus.ls.ext/com.redhat.quarkus.ls/src/main/resources/com/redhat/quarkus/snippets/quarkus-java.json since the jax-rs snippets are generic enough to include in lsp4mp. Not sure if they should be removed from quarkus.ls or kept in their as well?

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>