### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contribution Guide
+
+Contributions are extremely welcome, no matter how big or small. If you have any questions or suggestions we are happy to hear them.
+
+## Raising issues or feature requests
+
+Please raise any bug reports or feature requests on the [issue tracker](https://github.com/eclipse/lsp4mp/issues). Be sure to search the list to see if your issue has already been raised.
+
+A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong. Provide as much context as possible so we can try to recreate the issue.
+
+## Project Structure and implementing language features
+
+For documentation on project structure and how to implement new language features in lsp4mp you can look at the [contributing guide of vscode-microprofile](https://github.com/redhat-developer/vscode-microprofile/blob/master/CONTRIBUTING.md) which contains an overview of lsp4mp.
+
+## Eclipse Contributor Agreement
+
+Before your contribution can be accepted by the project, you need to create and electronically sign an [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ecafaq.php):
+
+1. Log in to the [Eclipse foundation website](https://accounts.eclipse.org/user/login/). You will need to
+   create an account with the Eclipse Foundation if you have not already done so.
+2. Click on "Eclipse ECA", and complete the form.
+
+Be sure to use the same email address in your Eclipse account that you intend to use when you commit to GitHub.
+All committers all commits are bound to the [Developer Certificate of Origin.](https://www.eclipse.org/legal/DCO.php)
+As such, all parties involved in a contribution must have valid ECAs and commits must include [valid "Signed-off-by" entries.](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git)
+Commits can be signed off by including the `-s` attribute in your commit message, for example, `git commit -s -m 'Interesting Commit Message.`


### PR DESCRIPTION
Adds a contributing guide.

For the project structure, for now I just linked to the vscode-microprofile contributing guide to avoid having to maintain the information in two places. This could be improved in the future if needed.

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>