### PR TITLE
Property expression highlight

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/AbstractTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/AbstractTextDocumentService.java
@@ -26,6 +26,8 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -87,6 +89,11 @@ public abstract class AbstractTextDocumentService implements TextDocumentService
 
 	@Override
 	public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
 		return CompletableFuture.completedFuture(null);
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/ApplicationPropertiesTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/ApplicationPropertiesTextDocumentService.java
@@ -35,6 +35,8 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -263,6 +265,13 @@ public class ApplicationPropertiesTextDocumentService extends AbstractTextDocume
 						}) //
 						.collect(Collectors.toList());
 			});
+		});
+	}
+
+	@Override
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
+		return getPropertiesModel(params.getTextDocument(), (cancelChecker, document) -> {
+			return getMicroProfileLanguageService().findDocumentHighlight(document, params.getPosition());
 		});
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileTextDocumentService.java
@@ -33,6 +33,8 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -199,6 +201,15 @@ public class MicroProfileTextDocumentService implements TextDocumentService {
 		TextDocumentService service = getTextDocumentService(params.getTextDocument());
 		if (service != null) {
 			return service.codeLens(params);
+		}
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
+		TextDocumentService service = getTextDocumentService(params.getTextDocument());
+		if (service != null) {
+			return service.documentHighlight(params);
 		}
 		return CompletableFuture.completedFuture(null);
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileDocumentHighlight.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileDocumentHighlight.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.lsp4mp.services;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4mp.ls.commons.BadLocationException;
+import org.eclipse.lsp4mp.model.Node;
+import org.eclipse.lsp4mp.model.PropertiesModel;
+import org.eclipse.lsp4mp.model.Property;
+import org.eclipse.lsp4mp.model.PropertyKey;
+import org.eclipse.lsp4mp.model.PropertyValueExpression;
+import org.eclipse.lsp4mp.model.Node.NodeType;
+import org.eclipse.lsp4mp.utils.PositionUtils;
+
+/**
+ * Highlight for micro profile config documents
+ */
+public class MicroProfileDocumentHighlight {
+
+	/**
+	 * Returns a list of highlights for a MicroProfile properties document
+	 *
+	 * @param document The MicroProfile properties document
+	 * @param position The position of the cursor
+	 * @return a list of highlights for a MicroProfile properties document
+	 */
+	public List<? extends DocumentHighlight> findDocumentHighlight(PropertiesModel document, Position position) {
+		try {
+			Node node = document.findNodeAt(position);
+			switch (node.getNodeType()) {
+				case PROPERTY_KEY:
+					return getPropertyKeyHighlight(document, (PropertyKey) node);
+				case PROPERTY_VALUE_EXPRESSION:
+					return getPropertyValueExpressionHighlight(document, (PropertyValueExpression) node);
+				default:
+					return Collections.emptyList();
+			}
+		} catch (BadLocationException e) {
+			return Collections.emptyList();
+		}
+	}
+
+	/**
+	 * Highlight the key portion of the assignment statement for the property that
+	 * the property expression references, or nothing
+	 *
+	 * @param document The properties model that is being worked with
+	 * @param node     The property value expression that the cursor is on
+	 * @return A singleton list that contains a highlight for the key in the
+	 *         assignment statement for the reference property, or an empty list
+	 */
+	private List<? extends DocumentHighlight> getPropertyValueExpressionHighlight(PropertiesModel document,
+			PropertyValueExpression node) {
+		String otherProp = node.getReferencedPropertyName();
+		if (otherProp == null || otherProp.isBlank()) {
+			return Collections.emptyList();
+		}
+		List<DocumentHighlight> highlights = new ArrayList<>(2);
+		highlights.add(createHighlight(node, DocumentHighlightKind.Read));
+		for (Node child : document.getChildren()) {
+			if (child.getNodeType() == NodeType.PROPERTY) {
+				Property property = (Property) child;
+				if (otherProp.equals(property.getPropertyName())) {
+					highlights.add(createHighlight(property.getKey(), DocumentHighlightKind.Write));
+					break;
+				}
+			}
+		}
+		return highlights;
+	}
+
+	/**
+	 * Highlight all the property expressions that reference the property that the
+	 * given property key represents
+	 *
+	 * @param document The properties model that is being worked with
+	 * @param node     The property key that the cursor is on
+	 * @return A list containing highlights for all property expressions in the
+	 *         document that reference the expression that the property key
+	 *         represents
+	 */
+	private List<? extends DocumentHighlight> getPropertyKeyHighlight(PropertiesModel document, PropertyKey node) {
+		String propertyName = node.getPropertyName();
+		if (propertyName == null || propertyName.isBlank()) {
+			return Collections.emptyList();
+		}
+		List<DocumentHighlight> highlights = new ArrayList<>();
+		highlights.add(createHighlight(node, DocumentHighlightKind.Write));
+		for (Node child : document.getChildren()) {
+			if (child.getNodeType() == NodeType.PROPERTY) {
+				Property property = (Property) child;
+				if (property.getValue() != null) {
+					for (Node valueSegment : ((Property) child).getValue().getChildren()) {
+						if (valueSegment.getNodeType() == NodeType.PROPERTY_VALUE_EXPRESSION && propertyName
+								.equals(((PropertyValueExpression) valueSegment).getReferencedPropertyName())) {
+							highlights.add(createHighlight(valueSegment, DocumentHighlightKind.Read));
+						}
+					}
+				}
+			}
+		}
+		return highlights;
+	}
+
+	/**
+	 * Returns a DocumentHighlight that highlights the given node
+	 *
+	 * @param n the node to highlight
+	 * @param kind the kind of the DocumentHighlight
+	 * @return a DocumentHighlight that highlights the given node
+	 */
+	private static DocumentHighlight createHighlight(Node n, DocumentHighlightKind kind) {
+		return new DocumentHighlight(PositionUtils.createRange(n), kind);
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileLanguageService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileLanguageService.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
@@ -56,6 +57,7 @@ public class MicroProfileLanguageService {
 	private final MicroProfileDiagnostics diagnostics;
 	private final MicroProfileFormatter formatter;
 	private final MicroProfileCodeActions codeActions;
+	private final MicroProfileDocumentHighlight documentHighlight;
 	private final ValuesRulesManager valuesRulesManager;
 
 	public MicroProfileLanguageService() {
@@ -70,6 +72,7 @@ public class MicroProfileLanguageService {
 		this.diagnostics = new MicroProfileDiagnostics();
 		this.formatter = new MicroProfileFormatter();
 		this.codeActions = new MicroProfileCodeActions();
+		this.documentHighlight = new MicroProfileDocumentHighlight();
 		this.valuesRulesManager = valuesRulesManger;
 	}
 
@@ -214,6 +217,10 @@ public class MicroProfileLanguageService {
 		updateProperties(projectInfo, document);
 		return codeActions.doCodeActions(context, range, document, projectInfo, getValuesRulesManager(),
 				formattingSettings, commandCapabilities);
+	}
+
+	public List<? extends DocumentHighlight> findDocumentHighlight(PropertiesModel document, Position position) {
+		return documentHighlight.findDocumentHighlight(document, position);
 	}
 
 	/**

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -79,6 +79,10 @@ public class ClientCapabilitiesWrapper {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getRangeFormatting());
 	}
 
+	public boolean isDocumentHighlightSupported() {
+		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getDocumentHighlight());
+	}
+
 	private boolean isDynamicRegistrationSupported(DynamicRegistrationCapabilities capability) {
 		return capability != null && capability.getDynamicRegistration() != null
 				&& capability.getDynamicRegistration().booleanValue();

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilityManager.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilityManager.java
@@ -22,6 +22,7 @@ import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstan
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.FORMATTING_ID;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.HOVER_ID;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.RANGE_FORMATTING_ID;
+import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DOCUMENT_HIGHLIGHT_ID;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_CODE_ACTION;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_CODE_LENS;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_COMPLETION;
@@ -30,6 +31,7 @@ import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstan
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_FORMATTING;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_HOVER;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_RANGE_FORMATTING;
+import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -107,6 +109,9 @@ public class MicroProfileCapabilityManager {
 		}
 		if (this.getClientCapabilities().isRangeFormattingDynamicRegistered()) {
 			registerCapability(RANGE_FORMATTING_ID, TEXT_DOCUMENT_RANGE_FORMATTING, getFormattingRegistrationOptions());
+		}
+		if (this.getClientCapabilities().isDocumentHighlightSupported()) {
+			registerCapability(DOCUMENT_HIGHLIGHT_ID, TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT, getFormattingRegistrationOptions());
 		}
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesConstants.java
@@ -35,6 +35,7 @@ public class ServerCapabilitiesConstants {
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_CODE_ACTION = "textDocument/codeAction";
 	public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
+	public static final String TEXT_DOCUMENT_DOCUMENT_HIGHLIGHT = "textDocument/documentHighlight";
 
 	public static final String COMPLETION_ID = UUID.randomUUID().toString();
 	public static final String HOVER_ID = UUID.randomUUID().toString();
@@ -44,6 +45,7 @@ public class ServerCapabilitiesConstants {
 	public static final String RANGE_FORMATTING_ID = UUID.randomUUID().toString();
 	public static final String CODE_ACTION_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
+	public static final String DOCUMENT_HIGHLIGHT_ID = UUID.randomUUID().toString();
 
 	public static final CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(false,
 			Arrays.asList(".", "%", "=", "$" /* triggered characters for properties file */ ,

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDocumentHighlightTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDocumentHighlightTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.lsp4mp.services;
+
+import org.junit.Test;
+
+import static org.eclipse.lsp4mp.services.MicroProfileAssert.r;
+import static org.eclipse.lsp4mp.services.MicroProfileAssert.assertDocumentHighlight;
+
+import org.eclipse.lsp4mp.ls.commons.BadLocationException;
+
+/**
+ * Tests for the document highlight in MicroProfile properties files
+ */
+public class ApplicationPropertiesDocumentHighlightTest {
+
+	@Test
+	public void keyHighlightOnePropertyExpression() throws BadLocationException {
+		String text = "ke|y = value\n" + //
+				"other.key = ${key}";
+		assertDocumentHighlight(text, r(0, 0, 3), r(1, 12, 18));
+	}
+
+	@Test
+	public void keyHighlightMultiplePropertyExpression() throws BadLocationException {
+		String text = "ke|y.one = value\n" + //
+				"key.two = ${key.one}\n" + //
+				"key.three = ${key.one}";
+		assertDocumentHighlight(text, //
+				r(0, 0, 7), //
+				r(1, 10, 20), //
+				r(2, 12, 22));
+	}
+
+	@Test
+	public void keyHighlightNoPropertyExpression() throws BadLocationException {
+		String text = "ke|y = value\n" + //
+				"other.key = ${cilantro}";
+		assertDocumentHighlight(text, r(0, 0, 3));
+	}
+
+	@Test
+	public void keyHighlightUnclosedPropertyExpression() throws BadLocationException {
+		String text = "ke|y = value\n" + //
+				"other.key = ${key";
+		assertDocumentHighlight(text, //
+				r(0, 0, 3), //
+				r(1, 12, 17));
+	}
+
+	@Test
+	public void keyHighlightUnaffectedByComment() throws BadLocationException {
+		String text = "ke|y = value\n" + //
+				"# hello this is a comment\n" + //
+				"# This is another comment\n" + //
+				"other.key = ${key";
+		assertDocumentHighlight(text, //
+				r(0, 0, 3), //
+				r(3, 12, 17));
+	}
+
+	@Test
+	public void keyHighlightCircularReference() throws BadLocationException {
+		String text = "|key = ${key}";
+		assertDocumentHighlight(text, //
+				r(0, 0, 3), //
+				r(0, 6, 12));
+	}
+
+	@Test
+	public void keyHighlightMultipleOnSameRow() throws BadLocationException {
+		String text = "key|.one = cool value\n" + //
+				"key.two = - ${key.one} - ${key.one}";
+		assertDocumentHighlight(text, //
+				r(0, 0, 7), //
+				r(1, 12, 22), //
+				r(1, 25, 35));
+	}
+
+	@Test
+	public void propertyExpressionHighlightKey() throws BadLocationException {
+		String text = "key = value\n" + //
+				"other.key = ${k|ey}";
+		assertDocumentHighlight(text, //
+				r(1, 12, 18), //
+				r(0, 0, 3));
+	}
+
+	@Test
+	public void propertyExpressionHighlightOnlyFirstKey() throws BadLocationException {
+		String text = "key = value\n" + //
+				"other.key = ${k|ey}" + //
+				"key = a different value";
+		assertDocumentHighlight(text, //
+				r(1, 12, 18), //
+				r(0, 0, 3));
+	}
+
+	@Test
+	public void expressionHighlightUnaffectedByComment() throws BadLocationException {
+		String text = "key = value\n" + //
+				"# hello this is a comment\n" + //
+				"# This is another comment\n" + //
+				"other.key = ${k|ey";
+		assertDocumentHighlight(text, //
+				r(3, 12, 17), //
+				r(0, 0, 3));
+	}
+
+	@Test
+	public void propertyExpressionHighlightCircularReference() throws BadLocationException {
+		String text = "key = ${ke|y}";
+		assertDocumentHighlight(text, //
+				r(0, 6, 12), //
+				r(0, 0, 3));
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/MicroProfileAssert.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverCapabilities;
@@ -152,7 +153,8 @@ public class MicroProfileAssert {
 		testCompletionFor(value, true, false, null, expectedItems.length, projectInfo, expectedItems);
 	}
 
-	public static void testCompletionFor(String value, MicroProfileProjectInfo projectInfo, Integer expectedCount) throws BadLocationException {
+	public static void testCompletionFor(String value, MicroProfileProjectInfo projectInfo, Integer expectedCount)
+			throws BadLocationException {
 		testCompletionFor(value, true, null, expectedCount, projectInfo);
 	}
 
@@ -672,6 +674,21 @@ public class MicroProfileAssert {
 				+ edits.stream().map(edit -> edit.getNewText()).collect(Collectors.joining(""))
 				+ value.substring(formatEnd);
 		Assert.assertEquals(expected, formatted);
+	}
+
+	// ------------------- Document Highlight Assert
+
+	public static void assertDocumentHighlight(String value, Range... expected) throws BadLocationException {
+		int offset = value.indexOf("|");
+		value = value.substring(0, offset) + value.substring(offset + 1);
+		TextDocument document = new TextDocument(value, "application.properties");
+		PropertiesModel model = parse(value, null);
+		MicroProfileLanguageService languageService = new MicroProfileLanguageService();
+		Object[] actual = languageService.findDocumentHighlight(model, document.positionAt(offset)).stream().map(dh -> {
+			return dh.getRange();
+		}).collect(Collectors.toList()).toArray();
+
+		Assert.assertArrayEquals(expected, actual);
 	}
 
 	private static PropertiesModel parse(String text, String uri) {


### PR DESCRIPTION
Highlights references when cursor is on a property key,
and the property key when the cursor
is on a reference (property expression).

Closes #40

Requires [the property expressions PR to be merged first](https://github.com/eclipse/lsp4mp/pull/13)

- [x] Tests

Signed-off-by: David Thompson <davthomp@redhat.com>