### PR TITLE
Fix missing unit in Gauge metrics snippet

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-metrics.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-metrics.json
@@ -37,7 +37,8 @@
     "body": [
       "@Gauge(",
       "\tname = \"${1:name}\",",
-      "\tdescription = \"${2:description}\"",
+      "\tdescription = \"${2:description}\",",
+      "\tunit = ${3|MetricUnits.NONE,MetricUnits.BYTES,MetricUnits.SECONDS,MetricUnits.PERCENT,\"\"|}",
       ")"
     ],
     "description": "Denotes a gauge, which samples the value of the annotated object.",


### PR DESCRIPTION
Adds unit to the `@Gauge` snippet since it is required https://github.com/eclipse/microprofile-metrics/blob/master/spec/src/main/asciidoc/app-programming-model.adoc#gauge

All others provide a default value so it is not needed. https://github.com/eclipse/microprofile-metrics/blob/master/spec/src/main/asciidoc/app-programming-model.adoc#fields