### PR TITLE
Add support for mp health properties

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -106,6 +106,11 @@
 
    <!-- Microprofile Health support -->
 
+   <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">
+      <!-- Properties provider for MicroProfile Health -->
+      <provider class="org.eclipse.lsp4mp.jdt.internal.health.properties.MicroProfileHealthProvider" />
+   </extension>
+   
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
       <!-- Java diagnostics for the MicroProfile Health -->
       <diagnostics class="org.eclipse.lsp4mp.jdt.internal.health.java.MicroProfileHealthDiagnosticsParticipant" />

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/health/properties/MicroProfileHealthProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/health/properties/MicroProfileHealthProvider.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4mp.jdt.internal.health.properties;
+
+import static org.eclipse.lsp4mp.jdt.internal.health.MicroProfileHealthConstants.LIVENESS_ANNOTATION;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.jdt.core.AbstractStaticPropertiesProvider;
+import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
+import org.eclipse.lsp4mp.jdt.core.SearchContext;
+import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
+
+/**
+ * Properties provider that provides static MicroProfile Health properties
+ * 
+ * @author Ryan Zegray
+ * 
+ * @see https://github.com/eclipse/microprofile-health/blob/master/spec/src/main/asciidoc/protocol-wireformat.adoc
+ *
+ */
+public class MicroProfileHealthProvider extends AbstractStaticPropertiesProvider {
+	public MicroProfileHealthProvider() {
+		super(MicroProfileCorePlugin.PLUGIN_ID, "/static-properties/mp-health-metadata.json");
+	}
+
+	@Override
+	protected boolean isAdaptedFor(SearchContext context, IProgressMonitor monitor) {
+		// Check if MicroProfile health exists in classpath
+		IJavaProject javaProject = context.getJavaProject();
+		return (JDTTypeUtils.findType(javaProject, LIVENESS_ANNOTATION) != null);
+	}
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/static-properties/mp-health-metadata.json
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/static-properties/mp-health-metadata.json
@@ -1,0 +1,11 @@
+{
+  "properties": [
+    {
+      "type": "boolean",
+      "extensionName": "microprofile-health-api",
+      "required": false,
+      "name": "mp.health.disable-default-procedures",
+      "description": "Disable all default vendor procedures and display only the user-defined health check procedures."
+    }
+  ]
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/MicroProfileHealthTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/MicroProfileHealthTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4mp.jdt.core.health;
+
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
+import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.junit.Test;
+
+/**
+ * Test the availability of the MicroProfile Health properties
+ * 
+ * @author Ryan Zegray
+ *
+ */
+public class MicroProfileHealthTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void microprofileContextPropagationPropertiesTest() throws Exception {
+
+		MicroProfileProjectInfo infoFromClasspath = getMicroProfileProjectInfoFromMavenProject(
+				MavenProjectName.microprofile_health_quickstart, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
+
+		assertProperties(infoFromClasspath,
+
+				p("microprofile-health-api", "mp.health.disable-default-procedures", "boolean",
+						"Disable all default vendor procedures and display only the user-defined health check procedures.", true,
+						null, null, null, 0, null)
+		);
+
+		assertPropertiesDuplicate(infoFromClasspath);
+	}
+
+}


### PR DESCRIPTION
Re-opening #18 

Fixes #16 

Adds support for the `mp.health.disable-default-procedures` property. (https://github.com/eclipse/microprofile-health/blob/master/spec/src/main/asciidoc/protocol-wireformat.adoc#disabling-default-vendor-procedures)

It looks like `mp.health.default.readiness.empty.response` was added recently (https://github.com/eclipse/microprofile-health/commit/2346c23d57f9972debf24fe3fc5eacf113b34231#diff-633b7a26b1aa3aed1e8853bc7355ae2cR170) and is not part of a mp health release yet. So i think it makes sense to wait and add it later.

![image](https://user-images.githubusercontent.com/16768710/88077203-00852b80-cb49-11ea-9dd1-03de57460308.png)
 
Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>