### PR TITLE
Rename settings prefix to microprofile

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/CommandKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/CommandKind.java
@@ -27,21 +27,21 @@ public class CommandKind {
 	/**
 	 * Client command to open references
 	 */
-	public static final String COMMAND_REFERENCES = "quarkus.command.references";
+	public static final String COMMAND_REFERENCES = "microprofile.command.references";
 
 	/**
 	 * Client command to open implementations
 	 */
-	public static final String COMMAND_IMPLEMENTATIONS = "quarkus.command.implementations";
+	public static final String COMMAND_IMPLEMENTATIONS = "microprofile.command.implementations";
 
 	/**
 	 * Client command to open URI
 	 */
-	public static final String COMMAND_OPEN_URI = "quarkus.command.open.uri";
+	public static final String COMMAND_OPEN_URI = "microprofile.command.open.uri";
 
 	/**
 	 * Client command to update client configuration settings
 	 */
-	public static final String COMMAND_CONFIGURATION_UPDATE = "quarkus.command.configuration.update";
+	public static final String COMMAND_CONFIGURATION_UPDATE = "microprofile.command.configuration.update";
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/InitializationOptionsExtendedClientCapabilities.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/InitializationOptionsExtendedClientCapabilities.java
@@ -24,7 +24,7 @@ import org.eclipse.lsp4mp.utils.JSONUtility;
 		"commands": {
 			"commandsKind": {
 				"valueSet": [
-					"quarkus.command.configuration.update"
+					"microprofile.command.configuration.update"
 				]
 			}
 		}
@@ -54,7 +54,7 @@ public class InitializationOptionsExtendedClientCapabilities {
 			"commands": {
 				"commandsKind": {
 					"valueSet": [
-						"quarkus.command.configuration.update"
+						"microprofile.command.configuration.update"
 					]
 				}
 			}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileCodeActions.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileCodeActions.java
@@ -244,18 +244,18 @@ class MicroProfileCodeActions {
 	/**
 	 * Returns a code action for <code>diagnostic</code> that causes
 	 * <code>item</code> to be added to
-	 * <code>quarkus.tools.validation.unknown.excluded</code> client configuration
+	 * <code>microprofile.tools.validation.unknown.excluded</code> client configuration
 	 *
 	 * @param item       the item to add to the client configuration array
 	 * @param diagnostic the diagnostic for the <code>CodeAction</code>
 	 * @return a code action that causes <code>item</code> to be added to
-	 *         <code>quarkus.tools.validation.unknown.excluded</code> client
+	 *         <code>microprofile.tools.validation.unknown.excluded</code> client
 	 *         configuration
 	 */
 	private CodeAction createAddToExcludedCodeAction(String item, Diagnostic diagnostic) {
 		CodeAction insertCodeAction = new CodeAction("Exclude '" + item + "' from unknown property validation?");
 
-		ConfigurationItemEdit configItemEdit = new ConfigurationItemEdit("quarkus.tools.validation.unknown.excluded",
+		ConfigurationItemEdit configItemEdit = new ConfigurationItemEdit("microprofile.tools.validation.unknown.excluded",
 				ConfigurationItemEditType.add, item);
 
 		Command command = new Command("Add " + item + " to unknown excluded array",

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/AllMicroProfileSettings.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/AllMicroProfileSettings.java
@@ -19,9 +19,9 @@ import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4mp.utils.JSONUtility;
 
 /**
- * Represents all settings under the 'quarkus' key
+ * Represents all settings under the 'microprofile' key
  *
- * { 'quarkus': {...} }
+ * { 'microprofile': {...} }
  */
 public class AllMicroProfileSettings {
 
@@ -37,20 +37,20 @@ public class AllMicroProfileSettings {
 	}
 
 	@JsonAdapter(JsonElementTypeAdapter.Factory.class)
-	private Object quarkus;
+	private Object microprofile;
 
 	/**
-	 * @return the quarkus
+	 * @return the microprofile
 	 */
-	public Object getQuarkus() {
-		return quarkus;
+	public Object getMicroProfile() {
+		return microprofile;
 	}
 
 	/**
-	 * @param quarkus the quarkus to set
+	 * @param microprofile the microprofile to set
 	 */
-	public void setQuarkus(Object quarkus) {
-		this.quarkus = quarkus;
+	public void setMicroProfile(Object microprofile) {
+		this.microprofile = microprofile;
 	}
 
 	public static Object getMicroProfileToolsSettings(Object initializationOptionsSettings) {
@@ -59,7 +59,7 @@ public class AllMicroProfileSettings {
 		if (rootSettings == null) {
 			return null;
 		}
-		ToolsSettings quarkusSettings = JSONUtility.toModel(rootSettings.getQuarkus(), ToolsSettings.class);
-		return quarkusSettings != null ? quarkusSettings.getTools() : null;
+		ToolsSettings microprofileSettings = JSONUtility.toModel(rootSettings.getMicroProfile(), ToolsSettings.class);
+		return microprofileSettings != null ? microprofileSettings.getTools() : null;
 	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/InitializationOptionsSettings.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/InitializationOptionsSettings.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4mp.utils.JSONUtility;
 /**
  * Represents all settings sent from the server
  *
- * { 'settings': { 'quarkus': {...}, 'http': {...} } }
+ * { 'settings': { 'microprofile': {...}, 'http': {...} } }
  */
 public class InitializationOptionsSettings {
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCodeActionsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesCodeActionsTest.java
@@ -227,16 +227,16 @@ public class ApplicationPropertiesCodeActionsTest {
 	/**
 	 * Returns a code action for <code>diagnostic</code> that causes
 	 * <code>item</code> to be added to
-	 * <code>quarkus.tools.validation.unknown.excluded</code> client configuration
+	 * <code>microprofile.tools.validation.unknown.excluded</code> client configuration
 	 * 
 	 * @param item       the item to add to the client configuration array
 	 * @param diagnostic the diagnostic for the <code>CodeAction</code>
 	 * @return a code action that causes <code>item</code> to be added to
-	 *         <code>quarkus.tools.validation.unknown.excluded</code> client
+	 *         <code>microprofile.tools.validation.unknown.excluded</code> client
 	 *         configuration
 	 */
 	private CodeAction caAddToExcluded(String item, Diagnostic diagnostic) {
-		ConfigurationItemEdit configItemEdit = new ConfigurationItemEdit("quarkus.tools.validation.unknown.excluded",
+		ConfigurationItemEdit configItemEdit = new ConfigurationItemEdit("microprofile.tools.validation.unknown.excluded",
 				ConfigurationItemEditType.add, item);
 
 		Command command = new Command("Add " + item + " to unknown excluded array",

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/settings/SettingsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/settings/SettingsTest.java
@@ -28,14 +28,10 @@ public class SettingsTest {
 
 	private final String json = "{\r\n" + 
 			"    \"settings\": {\r\n" + 
-			"        \"quarkus\": {\r\n" + 
+			"        \"microprofile\": {\r\n" + 
 			"            \"tools\": {\r\n" + 
 			"                \"trace\": {\r\n" + 
 			"                    \"server\": \"verbose\"\r\n" + 
-			"                },\r\n" + 
-			"                \"starter\": {\r\n" + 
-			"                    \"api\": \"http://code.quarkus.io/api\",\r\n" + 
-			"                    \"defaults\": {}\r\n" + 
 			"                },\r\n" + 
 			"                \"symbols\": {\r\n" + 
 			"                    \"showAsTree\": true\r\n" + 


### PR DESCRIPTION
Re-opening #4 

Changes prefix of settings and client commands to microprofile

See redhat-developer/quarkus-ls#325

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>