### PR TITLE
Fix duplicate of `quarkus-properties` when registering `textDocument/rangeFormatting`

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilityManager.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilityManager.java
@@ -54,7 +54,6 @@ public class MicroProfileCapabilityManager {
 	private final LanguageClient languageClient;
 
 	private ClientCapabilitiesWrapper clientWrapper;
-	private TextDocumentRegistrationOptions formattingRegistrationOptions;
 
 	private final List<IMicroProfileRegistrationConfiguration> registrationConfigurations;
 	private boolean registrationConfigurationsInitialized;
@@ -105,18 +104,15 @@ public class MicroProfileCapabilityManager {
 			 */
 			registerCapability(FORMATTING_ID, TEXT_DOCUMENT_FORMATTING, getFormattingRegistrationOptions());
 		}
-		if (this.getClientCapabilities().isFormattingDynamicRegistered()) {
+		if (this.getClientCapabilities().isRangeFormattingDynamicRegistered()) {
 			registerCapability(RANGE_FORMATTING_ID, TEXT_DOCUMENT_RANGE_FORMATTING, getFormattingRegistrationOptions());
 		}
 	}
 
 	private TextDocumentRegistrationOptions getFormattingRegistrationOptions() {
-		if (formattingRegistrationOptions == null) {
-			List<DocumentFilter> documentSelector = new ArrayList<>();
-			documentSelector.add(new DocumentFilter("microprofile-properties", null, null));
-			formattingRegistrationOptions = new TextDocumentRegistrationOptions(documentSelector);
-		}
-		return formattingRegistrationOptions;
+		List<DocumentFilter> documentSelector = new ArrayList<>();
+		documentSelector.add(new DocumentFilter("microprofile-properties", null, null));
+		return new TextDocumentRegistrationOptions(documentSelector);
 	}
 
 	public void setClientCapabilities(ClientCapabilities clientCapabilities,


### PR DESCRIPTION
Fix duplicate of `quarkus-properties` when registering `textDocument/rangeFormatting`

Fixes https://github.com/redhat-developer/vscode-quarkus/issues/296

Signed-off-by: azerr <azerr@redhat.com>