### PR TITLE
Add snippets for MP Rest Client

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/MicroProfileJavaSnippetRegistryLoader.java
@@ -28,17 +28,19 @@ public class MicroProfileJavaSnippetRegistryLoader implements ISnippetRegistryLo
 
 	@Override
 	public void load(SnippetRegistry registry) throws IOException {
-		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("jax-rs.json"),
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-restclient.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-metrics.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-openapi.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
-		registry.registerSnippets(
-				MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-faulttolerance.json"),
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-faulttolerance.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
 		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("mp-health.json"),
 				SnippetContextForJava.TYPE_ADAPTER);
+		registry.registerSnippets(MicroProfileJavaSnippetRegistryLoader.class.getResourceAsStream("jax-rs.json"),
+				SnippetContextForJava.TYPE_ADAPTER);
+
 	}
 
 	@Override

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-restclient.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-restclient.json
@@ -1,0 +1,38 @@
+{
+  "MicroProfile - new rest client": {
+    "prefix": "mpnrc",
+    "body": [
+      "package ${1:packagename};",
+      "",
+      "import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;",
+      "",
+      "import javax.enterprise.context.ApplicationScoped;",
+      "import javax.ws.rs.GET;",
+      "import javax.ws.rs.Path;",
+      "import javax.ws.rs.PathParam;",
+      "",
+      "@RegisterRestClient",
+      "@ApplicationScoped",
+      "public interface ${TM_FILENAME_BASE} {",
+      "",
+      "\t@GET",
+      "\t@Path(\"${2:/path}\")",
+      "\tString ${3:methodname}();",
+      "",
+      "}",
+      ""
+    ],
+    "description": "MicroProfile - new rest client",
+    "context": {
+      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient"
+    }
+  },
+  "MicroProfile - inject rest client": {
+    "prefix": "mpirc",
+    "body": ["@Inject", "@RestClient", "${1:Client} {2:client};"],
+    "description": "MicroProfile - inject rest client",
+    "context": {
+      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient"
+    }
+  }
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/ls/JavaTextDocumentSnippetRegistryTest.java
@@ -140,6 +140,31 @@ public class JavaTextDocumentSnippetRegistryTest {
 		Assert.assertNotNull("mpliveness snippet has context", livenessContext);
 	}
 
+	@Test
+	public void mpRestClientSnippets() {
+		Optional<Snippet> newRestClientSnippet = findByPrefix("mpnrc", registry);
+		Assert.assertTrue("Tests has new MicroProfile rest client Java snippets", newRestClientSnippet.isPresent());
+
+		ISnippetContext<?> context = newRestClientSnippet.get().getContext();
+		Assert.assertNotNull("mpnrc snippet has context", context);
+		Assert.assertTrue("mpnrc snippet context is Java context", context instanceof SnippetContextForJava);
+
+		ProjectLabelInfoEntry projectInfo = new ProjectLabelInfoEntry("", new ArrayList<>());
+		boolean match = ((SnippetContextForJava) context).isMatch(projectInfo);
+		Assert.assertFalse("Project has no org.eclipse.microprofile.rest.client.inject.RegisterRestClient type", match);
+
+		ProjectLabelInfoEntry projectInfo2 = new ProjectLabelInfoEntry("",
+				Arrays.asList("org.eclipse.microprofile.rest.client.inject.RegisterRestClient"));
+		boolean match2 = ((SnippetContextForJava) context).isMatch(projectInfo2);
+		Assert.assertTrue("Project has org.eclipse.microprofile.rest.client.inject.RegisterRestClient type", match2);
+
+		Optional<Snippet> injectRestClientSnippet = findByPrefix("mpirc", registry);
+		Assert.assertTrue("Tests has inject MicroProfile rest client Java snippets", injectRestClientSnippet.isPresent());
+
+		ISnippetContext<?> context2 = injectRestClientSnippet.get().getContext();
+		Assert.assertNotNull("mpirc snippet has context", context2);
+	}
+
 	private static Optional<Snippet> findByPrefix(String prefix, SnippetRegistry registry) {
 		return registry.getSnippets().stream().filter(snippet -> snippet.getPrefixes().contains(prefix)).findFirst();
 	}


### PR DESCRIPTION
Fixes #55 

Adds snippets for creating and injecting a new MicroProfile rest client.

Signed-off-by: Ryan Zegray <ryan.zegray@ibm.com>