### PR TITLE
Add diagnostic and quick fix for MP Metrics

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
@@ -42,6 +42,8 @@ Export-Package: io.quarkus.runtime.util,
  org.eclipse.lsp4mp.jdt.internal.faulttolerance;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.health;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.health.java;x-friends:="org.eclipse.lsp4mp.jdt.test",
+ org.eclipse.lsp4mp.jdt.internal.metrics;x-friends:="org.eclipse.lsp4mp.jdt.test",
+ org.eclipse.lsp4mp.jdt.internal.metrics.java;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.restclient;x-friends:="org.eclipse.lsp4mp.jdt.test"
 Bundle-ClassPath: lib/snakeyaml-1.25.jar,
  .

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -84,6 +84,15 @@
       <provider class="org.eclipse.lsp4mp.jdt.internal.metrics.properties.MicroProfileMetricsProvider" />
    </extension>
 
+   <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants" >
+      <!-- Java diagnostics for MicroProfile Metrics -->
+      <diagnostics class="org.eclipse.lsp4mp.jdt.internal.metrics.java.MicroProfileMetricsDiagnosticsParticipant" />
+      <!-- Java codeActions for MicroProfile Metrics -->
+      <codeAction kind="quickfix"
+                  targetDiagnostic="microprofile-metrics#ApplicationScopedAnnotationMissing"
+                  class="org.eclipse.lsp4mp.jdt.internal.metrics.java.ApplicationScopedAnnotationMissingQuickFix" />
+   </extension>
+   
    <!-- Microprofile OpenTracing support -->
 
    <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/codeaction/InsertAnnotationMissingQuickFix.java
@@ -86,6 +86,10 @@ public class InsertAnnotationMissingQuickFix implements IJavaCodeActionParticipa
 		return Bindings.getBindingOfParentType(node);
 	}
 
+	protected String[] getAnnotations() {
+		return this.annotations;
+	}
+
 	protected void insertAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, IBinding parentType,
 			List<CodeAction> codeActions) throws CoreException {
 		if (generateOnlyOneCodeAction) {

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/MicroProfileMetricsConstants.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/MicroProfileMetricsConstants.java
@@ -19,8 +19,21 @@ package org.eclipse.lsp4mp.jdt.internal.metrics;
  * @author David Kwon
  *
  */
-public class MicroProfileMetricsConstants{
+public class MicroProfileMetricsConstants {
 
 	public static final String METRIC_ID = "org.eclipse.microprofile.metrics.MetricID";
 
+	public static final String GAUGE_ANNOTATION = "org.eclipse.microprofile.metrics.Gauge";
+
+	public static final String DIAGNOSTIC_SOURCE = "microprofile-metrics";
+
+	// CDI Scope Annotations
+	public static final String APPLICATION_SCOPED_ANNOTATION = "javax.enterprise.context.ApplicationScoped";
+	public static final String REQUEST_SCOPED_ANNOTATION = "javax.enterprise.context.RequestScoped";
+	public static final String SESSION_SCOPED_ANNOTATION = "javax.enterprise.context.SessionScoped";
+	public static final String DEPENDENT_ANNOTATION = "javax.enterprise.context.Dependent";
+
+	public static final String REQUEST_SCOPED_ANNOTATION_NAME = "RequestScoped";
+	public static final String SESSION_SCOPED_ANNOTATION_NAME = "SessionScoped";
+	public static final String DEPENDENT_ANNOTATION_NAME = "Dependent";
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/ApplicationScopedAnnotationMissingQuickFix.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.metrics.java;
+
+import org.eclipse.lsp4mp.jdt.core.java.codeaction.InsertAnnotationMissingQuickFix;
+import org.eclipse.lsp4mp.jdt.internal.health.MicroProfileHealthConstants;
+import org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants;
+
+import src.main.java.org.eclipse.lsp4mp.jdt.core.java.corrections.proposal.ReplaceAnnotationProposal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4mp.jdt.core.java.codeaction.IJavaCodeActionParticipant;
+import org.eclipse.lsp4mp.jdt.core.java.codeaction.JavaCodeActionContext;
+import org.eclipse.lsp4mp.jdt.core.java.corrections.proposal.ChangeCorrectionProposal;
+import org.eclipse.lsp4mp.jdt.core.java.corrections.proposal.ImplementInterfaceProposal;
+
+/**
+ * QuickFix for fixing
+ * {@link MicroProfileMetricsErrorCode#ApplicationScopedAnnotationMissing} error
+ * by providing several code actions:
+ * 
+ * <ul>
+ * <li>Remove @RequestScoped | @SessionScoped | @Dependent annotation</li>
+ * <li>Insert @ApplicationScoped annotation and the proper import.</li>
+ * </ul>
+ * 
+ * @author Kathryn Kodama
+ *
+ */
+public class ApplicationScopedAnnotationMissingQuickFix extends InsertAnnotationMissingQuickFix {
+
+	private static final String[] REMOVE_ANNOTATION_NAMES = new String[] {
+			MicroProfileMetricsConstants.REQUEST_SCOPED_ANNOTATION_NAME,
+			MicroProfileMetricsConstants.SESSION_SCOPED_ANNOTATION_NAME,
+			MicroProfileMetricsConstants.DEPENDENT_ANNOTATION_NAME };
+
+	public ApplicationScopedAnnotationMissingQuickFix() {
+		super(MicroProfileMetricsConstants.APPLICATION_SCOPED_ANNOTATION);
+	}
+
+	@Override
+	protected void insertAnnotations(Diagnostic diagnostic, JavaCodeActionContext context, IBinding parentType,
+			List<CodeAction> codeActions) throws CoreException {
+		String[] annotations = getAnnotations();
+		for (String annotation : annotations) {
+			insertAndReplaceAnnotation(diagnostic, context, parentType, codeActions, annotation);
+		}
+	}
+
+	private static void insertAndReplaceAnnotation(Diagnostic diagnostic, JavaCodeActionContext context,
+			IBinding parentType, List<CodeAction> codeActions, String annotation) throws CoreException {
+		// Insert the annotation and the proper import by using JDT Core Manipulation
+		// API
+		String name = getLabel(annotation);
+		ChangeCorrectionProposal proposal = new ReplaceAnnotationProposal(name, context.getCompilationUnit(),
+				context.getASTRoot(), parentType, 0, annotation, REMOVE_ANNOTATION_NAMES);
+		// Convert the proposal to LSP4J CodeAction
+		CodeAction codeAction = context.convertToCodeAction(proposal, diagnostic);
+		if (codeAction != null) {
+			codeActions.add(codeAction);
+		}
+	}
+
+	private static String getLabel(String annotation) {
+		StringBuilder name = new StringBuilder("Replace current scope with ");
+		String annotationName = annotation.substring(annotation.lastIndexOf('.') + 1, annotation.length());
+		name.append("@");
+		name.append(annotationName);
+		return name.toString();
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.metrics.java;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaDiagnosticsParticipant;
+import org.eclipse.lsp4mp.jdt.core.java.diagnostics.JavaDiagnosticsContext;
+import org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
+import org.eclipse.lsp4mp.jdt.core.utils.PositionUtils;
+import org.eclipse.lsp4mp.jdt.internal.metrics.java.MicroProfileMetricsErrorCode;
+
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.METRIC_ID;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.GAUGE_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DIAGNOSTIC_SOURCE;
+
+/**
+ * 
+ * MicroProfile Metrics Diagnostics
+ * <ul>
+ * <li>Diagnostic 1: display @Gauge annotation diagnostic message if the
+ * underlying bean is annotated with @RequestScoped, @SessionScoped
+ * or @Dependent. Suggest that @AnnotationScoped is used instead.</li>
+ * </ul>
+ * 
+ * 
+ * @author Kathryn Kodama
+ * 
+ * @See https://github.com/eclipse/microprofile-metrics
+ */
+public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosticsParticipant {
+
+	@Override
+	public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor)
+			throws CoreException {
+		// Collection of diagnostics for MicroProfile Metrics is done only if
+		// microprofile-metrics is on the classpath
+		IJavaProject javaProject = context.getJavaProject();
+		return JDTTypeUtils.findType(javaProject, METRIC_ID) != null;
+	}
+
+	@Override
+	public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor)
+			throws CoreException {
+		ITypeRoot typeRoot = context.getTypeRoot();
+		IJavaElement[] elements = typeRoot.getChildren();
+		List<Diagnostic> diagnostics = new ArrayList<>();
+		collectDiagnostics(elements, diagnostics, context, monitor);
+		return diagnostics;
+	}
+
+	private static void collectDiagnostics(IJavaElement[] elements, List<Diagnostic> diagnostics,
+			JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException {
+		for (IJavaElement element : elements) {
+			if (monitor.isCanceled()) {
+				return;
+			}
+			if (element.getElementType() == IJavaElement.TYPE) {
+				IType type = (IType) element;
+				if (!type.isInterface()) {
+					validateClassType(type, diagnostics, context, monitor);
+				}
+				continue;
+			}
+		}
+	}
+
+	private static void validateClassType(IType classType, List<Diagnostic> diagnostics, JavaDiagnosticsContext context,
+			IProgressMonitor monitor) throws CoreException {
+		String uri = context.getUri();
+		IJDTUtils utils = context.getUtils();
+		DocumentFormat documentFormat = context.getDocumentFormat();
+		boolean hasInvalidScopeAnnotation = AnnotationUtils.hasAnnotation(classType, REQUEST_SCOPED_ANNOTATION)
+				|| AnnotationUtils.hasAnnotation(classType, SESSION_SCOPED_ANNOTATION)
+				|| AnnotationUtils.hasAnnotation(classType, DEPENDENT_ANNOTATION);
+		// check for Gauge annotation for Diagnostic 1 only if the class has an invalid
+		// scope annotation
+		if (hasInvalidScopeAnnotation) {
+			for (IJavaElement element : classType.getChildren()) {
+				if (monitor.isCanceled()) {
+					return;
+				}
+				if (element.getElementType() == IJavaElement.METHOD) {
+					IMethod field = (IMethod) element;
+					validateField(classType, field, diagnostics, context);
+				}
+			}
+		}
+	}
+
+	private static void validateField(IType classType, IMethod field, List<Diagnostic> diagnostics,
+			JavaDiagnosticsContext context) throws CoreException {
+		String uri = context.getUri();
+		DocumentFormat documentFormat = context.getDocumentFormat();
+		boolean hasGaugeAnnotation = AnnotationUtils.hasAnnotation(field, GAUGE_ANNOTATION);
+
+		// Diagnostic 1: display @Gauge annotation diagnostic message if
+		// the underlying bean is annotated with @RequestScoped, @SessionScoped or
+		// @Dependent.
+		// Suggest that @AnnotationScoped is used instead.</li>
+		if (hasGaugeAnnotation) {
+			Range cdiBeanRange = PositionUtils.toNameRange(classType, context.getUtils());
+			Diagnostic d = context.createDiagnostic(uri, createDiagnostic1Message(classType, documentFormat),
+					cdiBeanRange, DIAGNOSTIC_SOURCE, MicroProfileMetricsErrorCode.ApplicationScopedAnnotationMissing);
+			diagnostics.add(d);
+		}
+	}
+
+	private static String createDiagnostic1Message(IType classType, DocumentFormat documentFormat) {
+		StringBuilder message = new StringBuilder("The class ");
+		if (DocumentFormat.Markdown.equals(documentFormat)) {
+			message.append("`");
+		}
+		message.append(classType.getFullyQualifiedName());
+		if (DocumentFormat.Markdown.equals(documentFormat)) {
+			message.append("`");
+		}
+		message.append(
+				" using the @Gauge annotation should use the @ApplicationScoped annotation. The @Gauge annotation does not"
+						+ " support multiple instances of the underlying bean to be created.");
+		return message.toString();
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsErrorCode.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsErrorCode.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.metrics.java;
+
+import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaErrorCode;
+
+/**
+ * MicroProfile Metric diagnostics error code.
+ * 
+ * @author Kathryn Kodama
+ * 
+ */
+public enum MicroProfileMetricsErrorCode implements IJavaErrorCode {
+
+	ApplicationScopedAnnotationMissing;
+
+	@Override
+	public String getCode() {
+		return name();
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-metrics/src/main/java/org/acme/IncorrectScope.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-metrics/src/main/java/org/acme/IncorrectScope.java
@@ -1,0 +1,18 @@
+package org.acme;
+
+import javax.ws.rs.Path;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+@Path("/")
+public class IncorrectScope {
+
+	@Gauge(name = "Return Int", unit = MetricUnits.NONE, description = "Test method for Gauge annotation")
+	public int returnInt() {
+		return 2;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/JavaDiagnosticsMicroProfileMetricsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/JavaDiagnosticsMicroProfileMetricsTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.metrics;
+
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.ca;
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.d;
+import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.te;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeActionParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants;
+import org.eclipse.lsp4mp.jdt.internal.metrics.java.MicroProfileMetricsErrorCode;
+import org.junit.Test;
+
+/**
+ * Java diagnostics and code action for MicroProfile Metrics.
+ * 
+ * @author Kathryn Kodama
+ */
+public class JavaDiagnosticsMicroProfileMetricsTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void ApplicationScopedAnnotationMissing() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MavenProjectName.microprofile_metrics);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path("src/main/java/org/acme/IncorrectScope.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		// check for MicroProfile metrics diagnostic warning
+		Diagnostic d = d(10, 13, 27,
+				"The class `org.acme.IncorrectScope` using the @Gauge annotation should use the @ApplicationScoped annotation." + 
+				" The @Gauge annotation does not support multiple instances of the underlying bean to be created.",
+				DiagnosticSeverity.Warning, MicroProfileMetricsConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileMetricsErrorCode.ApplicationScopedAnnotationMissing);
+		assertJavaDiagnostics(diagnosticsParams, utils, d);
+
+		String uri = javaFile.getLocation().toFile().toURI().toString();
+		MicroProfileJavaCodeActionParams codeActionParams = createCodeActionParams(uri, d);
+		// check for MicroProfile metrics quick fix code action associated with diagnostic warning
+		assertJavaCodeAction(codeActionParams, utils, //
+			ca(uri, "Replace current scope with @ApplicationScoped", d, //
+				te(4, 57, 9, 0, "\n\nimport javax.enterprise.context.ApplicationScoped;\n" + //
+					"import javax.enterprise.context.RequestScoped;\n\n" + //
+					"@ApplicationScoped\n")));
+	}
+	
+}


### PR DESCRIPTION
Fixes #46 

Diagnostic warning displayed if a method in a class is annotated with `@Gauge` and the class is annotated with `@RequestScoped`, `@SessionScoped`, or `@Dependent`. Quick fix suggests replacing the current scope with `@ApplicationScoped`. 

See: https://github.com/eclipse/microprofile-metrics/blob/f9de52de9e1fe910de0f3ff1aa2949628eb1fc5a/spec/src/main/asciidoc/architecture.adoc#metrics-and-cdi-scopes

![image](https://user-images.githubusercontent.com/26146482/91201233-31b7c500-e6ce-11ea-9943-5426ea9ac131.png)
![image](https://user-images.githubusercontent.com/26146482/91201257-3a100000-e6ce-11ea-8efe-e241679bc0d3.png)
![image](https://user-images.githubusercontent.com/26146482/91201264-3bd9c380-e6ce-11ea-8fd8-b0f69a156908.png)

A new [ReplaceAnnotationProposal](https://github.com/eclipse/lsp4mp/compare/master...kathrynkodama:46-cdi-diagnostic?expand=1#diff-58a49c1846a7b43fb911d30e8525ab97) class created that extends the [NewAnnotationProposal](https://github.com/kathrynkodama/lsp4mp/blob/46223e6959d54ccb14fe92fecffc1c25c1de276a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/corrections/proposal/NewAnnotationProposal.java) class in order to add capability to delete existing annotations.  As a result, some fields in [NewAnnotationProposal](https://github.com/eclipse/lsp4mp/compare/master...kathrynkodama:46-cdi-diagnostic?expand=1#diff-9f63561a70b79fbd22614378fa4c774c) and [InsertAnnotationMissingQuickFix](https://github.com/eclipse/lsp4mp/compare/master...kathrynkodama:46-cdi-diagnostic?expand=1#diff-6c07a940dec25b2b7b42da770a76a0aa) were changed from `private` to `protected`.

Signed-off-by: Kathryn Kodama kathryn.s.kodama@gmail.com
