### PR TITLE
Use propertyName when checking unknown property exclusion list.

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/MicroProfileValidator.java
@@ -102,7 +102,7 @@ class MicroProfileValidator {
 			ItemMetadata metadata = MicroProfilePropertiesUtils.getProperty(propertyName, projectInfo);
 			if (metadata == null) {
 				// Validate Unknown property
-				validateUnknownProperty(propertyNameWithProfile, property);
+				validateUnknownProperty(propertyName, property);
 			} else {
 				// Validate property Value
 				validatePropertyValue(propertyNameWithProfile, metadata, property);

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDiagnosticsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/ApplicationPropertiesDiagnosticsTest.java
@@ -230,6 +230,24 @@ public class ApplicationPropertiesDiagnosticsTest {
 		// * pattern --> all errors are ignored
 		unknown.setExcluded(new String[] { "*" });
 		testDiagnosticsFor(value, 0, getDefaultMicroProfileProjectInfo(), settings);
+
+	};
+
+	@Test
+	public void validateUnknownPropertiesWithProfileExcludedWithPattern() throws BadLocationException {
+		String value = "kafka-streams.cache.max.bytes.buffering=10240\n" + //
+				"kafka-streams.metadata.max.age.ms=500\n" + //
+				"kafka-streams.metrics.recording.level=DEBUG\n" + //
+				"%test.kafka-streams.state.dir=target/data/kafka-data/stores";
+
+		MicroProfileValidationSettings settings = new MicroProfileValidationSettings();
+		MicroProfileValidationTypeSettings unknown = new MicroProfileValidationTypeSettings();
+		unknown.setSeverity("error");
+		settings.setUnknown(unknown);
+
+		// kafka-streams.* --> properties for a profile are ignored
+		unknown.setExcluded(new String[] { "kafka-streams.*" });
+		testDiagnosticsFor(value, 0, getDefaultMicroProfileProjectInfo(), settings);
 	};
 
 	@Test


### PR DESCRIPTION
- A valid property exclusion pattern will fail to match against
  propertyNameWithProfile due to the profile prefix not matching
- Resolves redhat-developer/vscode-quarkus#314

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>