### PR TITLE
Fix infinite loop in parser

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/parser/PropertiesParser.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/parser/PropertiesParser.java
@@ -155,7 +155,7 @@ public class PropertiesParser implements ParseContext {
 				ErrorEvent e = new ErrorEvent(location, location, "Unexpected end of input",
 						ErrorType.UNEXPECTED_END_OF_INPUT);
 				errorHandler.error(this, e);
-			} else if (current < 0x20) {
+			} else if (current < 0x20 && current != '\t') {
 				final Location location = getLocation();
 				ErrorEvent e = new ErrorEvent(location, location, "Expected a valid string character",
 						ErrorType.EXPECTED_STRING_CHARACTER);
@@ -221,7 +221,6 @@ public class PropertiesParser implements ParseContext {
 				break;
 			case Property:
 				handler.startProperty(this);
-				skipWhiteSpace();
 				if (!readPropertyKey()) {
 					// property name continues on the next line
 					parseState = ParseState.PropertyName;
@@ -236,8 +235,8 @@ public class PropertiesParser implements ParseContext {
 
 	/**
 	 * Reads the contents after a PropertyKey. This method should only be called
-	 * after a PropertyKey has been finsished reading: (ProperyKey.start != -1 and
-	 * ProperyKey.end != -1)
+	 * after a PropertyKey has been finished reading: (PropertyKey.start != -1 and
+	 * PropertyKey.end != -1)
 	 */
 	private void readAfterPropertyKey() {
 		skipWhiteSpace();

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/parser/PropertiesModelTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/parser/PropertiesModelTest.java
@@ -312,6 +312,26 @@ public class PropertiesModelTest {
 		Assert.assertEquals("}", pvl.getText());
 	}
 
+	@Test
+	public void parsePropertyWithTrailingTab() {
+		String text = "property = hello, world!\t";
+		PropertiesModel model = PropertiesModel.parse(text, "microprofile-config.properties");
+		Assert.assertEquals(1, model.getChildren().size());
+		Property property0 = (Property) model.getChildren().get(0);
+		assertPropertyValue(property0, //
+				new MockNode(11, 25, NodeType.PROPERTY_VALUE_LITERAL));
+	}
+
+	@Test
+	public void parsePropertyWithTrailingSpace() {
+		String text = "property = hello, world! ";
+		PropertiesModel model = PropertiesModel.parse(text, "microprofile-config.properties");
+		Assert.assertEquals(1, model.getChildren().size());
+		Property property0 = (Property) model.getChildren().get(0);
+		assertPropertyValue(property0, //
+				new MockNode(11, 25, NodeType.PROPERTY_VALUE_LITERAL));
+	}
+
 	private static void assertComments(Node comments, int expectedStart, int expectedEnd, String expectedText) {
 		Assert.assertEquals(comments.getNodeType(), NodeType.COMMENTS);
 		Assert.assertEquals(expectedText, comments.getText());


### PR DESCRIPTION
Leaving a trailing tab character in microprofile-config.properties file would cause the parser to enter an infinite loop.

Closes #112

Signed-off-by: David Thompson <davthomp@redhat.com>