### PR TITLE
Replace 'ps -p' with 'kill -0' in ParentProcessWatcher

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/ParentProcessWatcher.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/ParentProcessWatcher.java
@@ -88,7 +88,7 @@ public final class ParentProcessWatcher implements Runnable, Function<MessageCon
 		if (isWindows) {
 			command = "cmd /c \"tasklist /FI \"PID eq " + pid + "\" | findstr " + pid + "\"";
 		} else {
-			command = "ps -p " + pid;
+			command = "kill -0 " + pid;
 		}
 		Process process = null;
 		boolean finished = false;


### PR DESCRIPTION
Fixes #110