### PR TITLE
Support arbitrary number of member values in PropertiesHoverParticipant.

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -14,7 +14,7 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>0.52.1.20200318153300</jdt.ls.version>
+    <jdt.ls.version>0.57.0.20200619102332</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
We should add support for any amount of member values for a given
annotation in addition to continued support for a single member value
and an optional default value member.

- Related redhat-developer/quarkus-ls#376

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>