### PR TITLE
Move MicroProfileForJavaAssert into internal.core class.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
@@ -32,5 +32,4 @@ Export-Package: org.eclipse.lsp4mp.jdt.core,
  org.eclipse.lsp4mp.jdt.core.metrics,
  org.eclipse.lsp4mp.jdt.core.openapi,
  org.eclipse.lsp4mp.jdt.core.opentracing,
- org.eclipse.lsp4mp.jdt.core.restclient,
- org.eclipse.lsp4mp.jdt.internal.core
+ org.eclipse.lsp4mp.jdt.core.restclient

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4mp.commons.DocumentFormat;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.eclipse.lsp4mp.jdt.internal.core.JavaUtils;
 import org.eclipse.lsp4mp.jdt.internal.core.JobHelpers;
 import org.eclipse.lsp4mp.jdt.internal.core.ls.JDTUtilsLSImpl;
 import org.junit.AfterClass;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/ConfigItemIntBoolDefaultValueTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/ConfigItemIntBoolDefaultValueTest.java
@@ -16,9 +16,9 @@ package org.eclipse.lsp4mp.jdt.core;
 import static org.eclipse.lsp4mp.commons.metadata.ItemMetadata.CONFIG_PHASE_BUILD_AND_RUN_TIME_FIXED;
 import static org.eclipse.lsp4mp.commons.metadata.ItemMetadata.CONFIG_PHASE_BUILD_TIME;
 import static org.eclipse.lsp4mp.commons.metadata.ItemMetadata.CONFIG_PHASE_RUN_TIME;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/JavaUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/JavaUtils.java
@@ -11,7 +11,7 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.core;
+package org.eclipse.lsp4mp.jdt.core;
 
 import java.io.File;
 import java.io.IOException;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileAssert.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileAssert.java
@@ -11,7 +11,7 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.core;
+package org.eclipse.lsp4mp.jdt.core;
 
 import java.util.Arrays;
 import java.util.List;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileConfigPropertyTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileConfigPropertyTest.java
@@ -15,9 +15,9 @@ package org.eclipse.lsp4mp.jdt.core;
 
 import static org.eclipse.lsp4mp.commons.metadata.ItemMetadata.CONFIG_PHASE_BUILD_AND_RUN_TIME_FIXED;
 import static org.eclipse.lsp4mp.commons.metadata.ItemMetadata.CONFIG_PHASE_BUILD_TIME;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileForJavaAssert.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileForJavaAssert.java
@@ -11,7 +11,7 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.core.java;
+package org.eclipse.lsp4mp.jdt.core;
 
 import static org.junit.Assert.assertEquals;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerClassPathKindTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerClassPathKindTest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import java.io.File;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerTest.java
@@ -13,7 +13,7 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.JavaUtils.getJarPath;
+import static org.eclipse.lsp4mp.jdt.core.JavaUtils.getJarPath;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
@@ -13,11 +13,11 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.config;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDefinitions;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.def;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.fixURI;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.r;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDefinitions;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.def;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
 
 import java.io.IOException;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaHoverTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaHoverTest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.config;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaHover;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.fixURI;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.h;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaHover;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.h;
 
 import java.io.IOException;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/contextpropagation/MicroProfileContextPropagationTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/contextpropagation/MicroProfileContextPropagationTest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.contextpropagation;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaDefinitionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaDefinitionTest.java
@@ -13,11 +13,11 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.faulttolerance;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDefinitions;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.def;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.fixURI;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.r;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDefinitions;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.def;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Path;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaDiagnosticsTest.java
@@ -13,8 +13,8 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.faulttolerance;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDiagnostics;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.d;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.d;
 
 import java.util.Arrays;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultTolerancePropertiesTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultTolerancePropertiesTest.java
@@ -13,13 +13,13 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.faulttolerance;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHints;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHintsDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.h;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.vh;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHints;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHintsDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.h;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.vh;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/graphql/MicroProfileGraphQLTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/graphql/MicroProfileGraphQLTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.lsp4mp.jdt.core.graphql;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/JavaDiagnosticsMicroProfileHealthTest.java
@@ -13,12 +13,12 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.health;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaCodeAction;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDiagnostics;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.ca;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.createCodeActionParams;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.d;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.te;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.ca;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.d;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.te;
 
 import java.util.Arrays;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/MicroProfileHealthTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/health/MicroProfileHealthTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.lsp4mp.jdt.core.health;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jwt/MicroProfileJWTPropertiesTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jwt/MicroProfileJWTPropertiesTest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.jwt;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/lra/MicroProfileLRATest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/lra/MicroProfileLRATest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.lra;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/JavaDiagnosticsMicroProfileMetricsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/JavaDiagnosticsMicroProfileMetricsTest.java
@@ -13,12 +13,12 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.metrics;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaCodeAction;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDiagnostics;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.ca;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.createCodeActionParams;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.d;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.te;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.ca;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.d;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.te;
 
 import java.util.Arrays;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/MicroProfileMetricsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/metrics/MicroProfileMetricsTest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.metrics;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/openapi/GenerateOpenAPIAnnotationsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/openapi/GenerateOpenAPIAnnotationsTest.java
@@ -13,10 +13,10 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.openapi;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaCodeAction;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.ca;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.createCodeActionParams;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.te;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.ca;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.te;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Path;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/openapi/MicroProfileOpenAPITest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/openapi/MicroProfileOpenAPITest.java
@@ -13,9 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.openapi;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/opentracing/MicroProfileOpenTracingTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/opentracing/MicroProfileOpenTracingTest.java
@@ -13,13 +13,13 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.opentracing;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHints;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHintsDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.h;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.vh;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHints;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHintsDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.h;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.vh;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/reactivemessaging/MicroProfileReactiveMessagingTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/reactivemessaging/MicroProfileReactiveMessagingTest.java
@@ -13,13 +13,13 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.reactivemessaging;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHints;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHintsDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.h;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.vh;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHints;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHintsDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.h;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.vh;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/JavaDiagnosticsMicroProfileRestClientTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/JavaDiagnosticsMicroProfileRestClientTest.java
@@ -13,12 +13,12 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.restclient;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaCodeAction;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.assertJavaDiagnostics;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.ca;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.createCodeActionParams;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.d;
-import static org.eclipse.lsp4mp.jdt.internal.core.java.MicroProfileForJavaAssert.te;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaCodeAction;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertJavaDiagnostics;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.ca;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.createCodeActionParams;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.d;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.te;
 
 import java.util.Arrays;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/MicroProfileRegisterRestClientTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/MicroProfileRegisterRestClientTest.java
@@ -13,13 +13,13 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.restclient;
 
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHints;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertHintsDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertProperties;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.assertPropertiesDuplicate;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.h;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.p;
-import static org.eclipse.lsp4mp.jdt.internal.core.MicroProfileAssert.vh;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHints;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertHintsDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertProperties;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.assertPropertiesDuplicate;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.h;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.vh;
 
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/MicroProfilePropertiesListenerManagerTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/MicroProfilePropertiesListenerManagerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesChangeEvent;
 import org.eclipse.lsp4mp.jdt.core.IMicroProfilePropertiesChangedListener;
+import org.eclipse.lsp4mp.jdt.core.JavaUtils;
 import org.eclipse.lsp4mp.jdt.core.utils.JDTMicroProfileUtils;
 import org.eclipse.lsp4mp.jdt.internal.core.MicroProfilePropertiesListenerManager;
 import org.junit.After;


### PR DESCRIPTION
- Related #376
- Move MicroProfileForJavaAssert from the restricted
  org.eclipse.lsp4mp.jdt.internal.core.java into the already exported
  org.eclipse.lsp4mp.jdt.internal.core .

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>