### PR TITLE
Release OSGi bundles with qualifiers.

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                 ./mvnw clean deploy -B -Peclipse-sign -Dcbi.jarsigner.skip=false
 
                 cd ../../microprofile.jdt
-                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=$VERSION
+                ./mvnw -Dtycho.mode=maven org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=$VERSION-SNAPSHOT
                 ./mvnw versions:set-scm-tag -DnewTag=$VERSION
                 ./mvnw clean verify -B  -Peclipse-sign
                 cd ..


### PR DESCRIPTION
- Since snapshot releases (including qualifiers) are available, we
  should preserve these in the release to ensure a proper upgrade path.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>