### PR TITLE
Fix 0.2.1

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
           sh '''
             git config --global user.email "lsp4mp-bot@eclipse.org"
             git config --global user.name "LSP4MP GitHub Bot"
-            git add **/pom.xml **/MANIFEST.MF
+            git add "**/pom.xml" "**/MANIFEST.MF"
             git commit -sm "Release $VERSION"
             git tag $VERSION
             git push origin $VERSION

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.lsp4mp.jdt.core;singleton:=true
-Bundle-Version: 0.2.0
+Bundle-Version: 0.2.1.qualifier
 Bundle-Activator: org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.2.0</version>
+		<version>0.2.1-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.lsp4mp.jdt.core</artifactId>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.2.0</version>
+		<version>0.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4mp.jdt.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: quarkus.jdt.ls Test Plugin
 Bundle-SymbolicName: org.eclipse.lsp4mp.jdt.test
-Bundle-Version: 0.2.0
+Bundle-Version: 0.2.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
  org.apache.commons.io,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.2.0</version>
+		<version>0.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4mp.jdt.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lsp4mp</groupId>
   <artifactId>parent</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>microprofile.jdt.ls :: parent</name>
   <description>microprofile.jdt.ls parent</description>
@@ -30,7 +30,7 @@
 		<connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>
 		<developerConnection>scm:git:git@github.com:eclipse/lsp4mp.git</developerConnection>
 		<url>https://github.com/eclipse/lsp4mp</url>
-		<tag>0.2.0</tag>
+		<tag>0.2.1</tag>
 	</scm>
   <repositories>
     <repository>

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lsp4mp</groupId>
 	<artifactId>org.eclipse.lsp4mp.ls</artifactId>
-	<version>0.2.0</version>
+	<version>0.2.1</version>
 
 	<name>MicroProfile Language Server</name>
 	<description>MicroProfile Language Server</description>
@@ -20,7 +20,7 @@
 		<connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>
 		<developerConnection>scm:git:git@github.com:eclipse/lsp4mp.git</developerConnection>
 		<url>https://github.com/eclipse/lsp4mp</url>
-		<tag>0.2.0</tag>
+		<tag>0.2.1</tag>
 	</scm>
 
 	<properties>


### PR DESCRIPTION
@datho7561 @fbricon 

So our 0.2.1 build is fine, but the tag needs updating because the build bot didn't stage all pom changes. Here's a local example.

```
$ git status
On branch upversion-0.3.0
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
	modified:   microprofile.jdt/pom.xml
	modified:   microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
no changes added to commit (use "git add" and/or "git commit -a")

$ git add **/pom.xml **/MANIFEST.MF

$ git status
On branch upversion-0.3.0
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
	modified:   microprofile.jdt/pom.xml
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
	modified:   microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
	modified:   microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
```

Quoting **/pom.xml and **/MANIFEST.MF fixes the behaviour.

Is it possible to apply this change on top of the current 0.2.1 tag commit, and re-tag this committed change as 0.2.1 ?
(ie. we don't want to merge this into master since that's not how the bot generally handles release commits)