### PR TITLE
Recognize `application.yml` as a configuration source

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProject.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProject.java
@@ -38,12 +38,15 @@ public class JDTMicroProfileProject {
 	public static final String APPLICATION_PROPERTIES_FILE = "application.properties";
 	@Deprecated
 	public static final String APPLICATION_YAML_FILE = "application.yaml";
+	@Deprecated
+	public static final String APPLICATION_YML_FILE = "application.yml";
 
 	private final List<IConfigSource> configSources;
 
 	public JDTMicroProfileProject(IJavaProject javaProject) {
 		this.configSources = new ArrayList<IConfigSource>(3);
 		configSources.add(new YamlConfigSource(APPLICATION_YAML_FILE, javaProject));
+		configSources.add(new YamlConfigSource(APPLICATION_YML_FILE, javaProject));
 		configSources.add(new PropertiesConfigSource(APPLICATION_PROPERTIES_FILE, javaProject));
 		configSources.add(new PropertiesConfigSource(MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject));
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
@@ -43,6 +43,7 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 	@After
 	public void cleanup() throws JavaModelException, IOException {
 		deleteFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, javaProject);
+		deleteFile(JDTMicroProfileProject.APPLICATION_YML_FILE, javaProject);
 		deleteFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, javaProject);
 		deleteFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject);
 	}
@@ -99,6 +100,29 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 		// Position(23, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.missing")
 		assertJavaDefinitions(p(23, 33), javaFileUri, JDT_UTILS);
+
+	}
+
+	@Test
+	public void configPropertyNameDefinitionYml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile applicationYmlFile = project.getFile(new Path("src/main/resources/application.yml"));
+		String applicationYmlFileUri = fixURI(applicationYmlFile.getLocation().toFile().toURI());
+
+		saveFile(JDTMicroProfileProject.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+				"  message: hello\n" + //
+				"  name: quarkus\n" + //
+				"  number: 100\n",
+				javaProject);
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaDefinitions(p(14, 40), javaFileUri, JDT_UTILS, //
+				def(r(14, 28, 44), applicationYmlFileUri, "greeting.message"));
 
 	}
 


### PR DESCRIPTION
Most features for YAML configuration files already work in both `application.yml` and `application.yaml`. However, this PR fixes the following features which were previously only working for `application.yaml`:

 * Hovering a `@ConfigProperty` annotation's `name` field shows the value that's defined in the config file, along with a link to the config file.
 * Invoking "Go to definition" on a `@ConfigProperty` annotation's `name` field opens the configuration file

Closes redhat-developer/quarkus-ls#373

Signed-off-by: David Thompson <davthomp@redhat.com>
