### PR TITLE
Extension point for contributing configuration sources

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.lsp4mp.jdt.core;singleton:=true
-Bundle-Version: 0.3.1.qualifier
+Bundle-Version: 0.4.0.qualifier
 Bundle-Activator: org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
@@ -39,6 +39,7 @@ Export-Package: io.quarkus.runtime.util,
  org.eclipse.lsp4mp.jdt.internal.core;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.core.ls;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.core.utils;x-friends:="org.eclipse.lsp4mp.jdt.test",
+ org.eclipse.lsp4mp.jdt.internal.core.providers;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.faulttolerance;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.faulttolerance.java;x-friends:="org.eclipse.lsp4mp.jdt.test",
  org.eclipse.lsp4mp.jdt.internal.health;x-friends:="org.eclipse.lsp4mp.jdt.test",

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -11,6 +11,9 @@
    <extension-point id="projectLabelProviders" 
                     name="%projectLabelProviders.name" 
                     schema="schema/projectLabelProviders.exsd"/>
+   <extension-point id="configSourceProviders"
+                    name="%configSourceProviders.name"
+                    schema="schema/configSourceProviders.exsd"/>
 
    <!-- Delegate command handler for application.properties file -->
    <extension point="org.eclipse.jdt.ls.core.delegateCommandHandler">
@@ -45,6 +48,12 @@
       <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.MavenProjectLabelProvider" />
       <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.GradleProjectLabelProvider" />
       <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.MicroProfileProjectLabelProvider" />
+   </extension>
+
+   <!-- Configuration sources -->
+   <extension point="org.eclipse.lsp4mp.jdt.core.configSourceProviders">
+      <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider" />
+      <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.QuarkusConfigSourceProvider" />
    </extension>
 
    <!-- Java Util Logging Config support -->

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.3.1-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.eclipse.lsp4mp.jdt.core</artifactId>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/schema/configSourceProviders.exsd
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/schema/configSourceProviders.exsd
@@ -1,0 +1,104 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.lsp4mp.jdt.core" xmlns="http://www.w3.org/2001/XMLSchema">
+   <annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.lsp4mp.jdt.core" id="configSourceProviders" name="%configSourceProviders.name"/>
+      </appinfo>
+      <documentation>
+         This extension point allows extensions to contribute additional configuration sources for a given Java project.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="provider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="provider">
+      <annotation>
+         <documentation>
+            TODO
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of a class that implements IConfigSourceProvider.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         0.4.0
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         See IConfigSourceProvider
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         DefaultMicroProfilePropertiesConfigSourceProvider: provides support for microprofile-config.properties 
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
@@ -412,7 +412,7 @@ public class PropertiesManager {
 	}
 
 	List<IPropertiesProvider> getPropertiesProviders() {
-		return PropertiesProviderRegistry.getInstance().getPropertiesProviders();
+		return PropertiesProviderRegistry.getInstance().getProviders();
 	}
 
 	// ---------------------------------- Properties definition

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSource.java
@@ -11,11 +11,9 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.core.project;
+package org.eclipse.lsp4mp.jdt.core.project;
 
 import java.util.Map;
-
-import org.eclipse.lsp4mp.jdt.core.project.MicroProfileConfigPropertyInformation;
 
 /**
  * Configuration file API
@@ -52,7 +50,7 @@ public interface IConfigSource {
 
 	/**
 	 * Returns the source file URI of the associated config file
-	 * 
+	 *
 	 * @return the source file URI of the associated config file
 	 */
 	String getSourceConfigFileURI();
@@ -73,5 +71,16 @@ public interface IConfigSource {
 	 *         this config source
 	 */
 	Map<String, MicroProfileConfigPropertyInformation> getPropertyInformations(String propertyKey);
+
+	/**
+	 * Returns the ordinal for this config source
+	 *
+	 * See https://download.eclipse.org/microprofile/microprofile-config-2.0/microprofile-config-spec-2.0.html#_configsource_ordering
+	 *
+	 * @return the ordinal for this config source
+	 */
+	default int getOrdinal() {
+		return 100;
+	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSourceProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSourceProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.project;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+/**
+ * Config source provider API
+ *
+ * @author datho7561
+ */
+public interface IConfigSourceProvider {
+
+	/**
+	 * Returns a list of configuration sources for a given Java project
+	 *
+	 * @param project the Java project to get configuration sources for
+	 * @return a list of configuration sources for a given Java project
+	 */
+	List<IConfigSource> getConfigSources(IJavaProject project);
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/PropertiesConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/PropertiesConfigSource.java
@@ -11,7 +11,7 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.core.project;
+package org.eclipse.lsp4mp.jdt.core.project;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.lsp4mp.jdt.core.project.MicroProfileConfigPropertyInformation;
+import org.eclipse.lsp4mp.jdt.internal.core.project.AbstractConfigSource;
 
 /**
  * {@link Properties} config file implementation.
@@ -30,8 +30,16 @@ import org.eclipse.lsp4mp.jdt.core.project.MicroProfileConfigPropertyInformation
  */
 public class PropertiesConfigSource extends AbstractConfigSource<Properties> {
 
+	private final int ordinal;
+
+	public PropertiesConfigSource(String configFileName, IJavaProject javaProject, int ordinal) {
+		super(configFileName, javaProject);
+		this.ordinal = ordinal;
+	}
+
 	public PropertiesConfigSource(String configFileName, IJavaProject javaProject) {
 		super(configFileName, javaProject);
+		this.ordinal = super.getOrdinal();
 	}
 
 	@Override
@@ -63,6 +71,11 @@ public class PropertiesConfigSource extends AbstractConfigSource<Properties> {
 					});
 		}
 		return infos;
+	}
+
+	@Override
+	public int getOrdinal() {
+		return ordinal;
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/AbstractMicroProfileProviderRegistry.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/AbstractMicroProfileProviderRegistry.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionDelta;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.IRegistryChangeEvent;
+import org.eclipse.core.runtime.IRegistryChangeListener;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.lsp4mp.jdt.core.IPropertiesProvider;
+import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider;
+
+/**
+ * Registry to hold providers for an extension point
+ *
+ * @param T the interface that the providers implement
+ * @author datho7561
+ */
+public abstract class AbstractMicroProfileProviderRegistry<T> implements IRegistryChangeListener {
+
+	private static final String CLASS_ATTR = "class";
+
+	private static final Logger LOGGER = Logger.getLogger(AbstractMicroProfileProviderRegistry.class.getName());
+
+	private boolean extensionProvidersLoaded;
+	private boolean registryListenerIntialized;
+	private final List<T> providers;
+
+	public AbstractMicroProfileProviderRegistry() {
+		super();
+		this.extensionProvidersLoaded = false;
+		this.registryListenerIntialized = false;
+		this.providers = new ArrayList<>();
+	}
+
+	/**
+	 * Returns the extension id of the provider extension point
+	 *
+	 * @return the extension id of the provider extension point
+	 */
+	public abstract String getProviderExtensionId();
+
+	/**
+	 * Returns all the providers.
+	 *
+	 * @return all the providers.
+	 */
+	public List<T> getProviders() {
+		loadExtensionProviders();
+		return providers;
+	}
+
+	private synchronized void loadExtensionProviders() {
+		if (extensionProvidersLoaded)
+			return;
+
+		// Immediately set the flag, as to ensure that this method is never
+		// called twice
+		extensionProvidersLoaded = true;
+
+		LOGGER.log(Level.INFO, "->- Loading ." + getProviderExtensionId() + " extension point ->-");
+
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		IConfigurationElement[] cf = registry.getConfigurationElementsFor(MicroProfileCorePlugin.PLUGIN_ID,
+				getProviderExtensionId());
+		addExtensionProviders(cf);
+		addRegistryListenerIfNeeded();
+
+		LOGGER.log(Level.INFO, "-<- Done loading ." + getProviderExtensionId() + " extension point -<-");
+	}
+
+	@Override
+	public void registryChanged(final IRegistryChangeEvent event) {
+		IExtensionDelta[] deltas = event.getExtensionDeltas(MicroProfileCorePlugin.PLUGIN_ID,
+				getProviderExtensionId());
+		if (deltas != null) {
+			synchronized (this) {
+				for (IExtensionDelta delta : deltas) {
+					IConfigurationElement[] cf = delta.getExtension().getConfigurationElements();
+					if (delta.getKind() == IExtensionDelta.ADDED) {
+						addExtensionProviders(cf);
+					} else {
+						removeExtensionProviders(cf);
+					}
+				}
+			}
+		}
+	}
+
+	private void addExtensionProviders(IConfigurationElement[] cf) {
+		for (IConfigurationElement ce : cf) {
+			try {
+				T provider = (T) ce.createExecutableExtension(CLASS_ATTR);
+				synchronized (providers) {
+					providers.add(provider);
+				}
+				LOGGER.log(Level.INFO, "  Loaded " + getProviderExtensionId() + ": " + provider.getClass().getName());
+			} catch (Throwable t) {
+				LOGGER.log(Level.SEVERE, "  Loaded while loading " + getProviderExtensionId(), t);
+			}
+		}
+	}
+
+	private void removeExtensionProviders(IConfigurationElement[] cf) {
+		for (IConfigurationElement ce : cf) {
+			try {
+				IPropertiesProvider provider = (IPropertiesProvider) ce.createExecutableExtension(CLASS_ATTR);
+				synchronized (providers) {
+					providers.remove(provider);
+				}
+				LOGGER.log(Level.INFO, "  Unloaded propertiesProviders: " + provider.getClass().getName());
+			} catch (Throwable t) {
+				LOGGER.log(Level.SEVERE, "  Unloaded while loading  propertiesProviders", t);
+			}
+		}
+	}
+
+	private void addRegistryListenerIfNeeded() {
+		if (registryListenerIntialized)
+			return;
+
+		IExtensionRegistry registry = Platform.getExtensionRegistry();
+		registry.addRegistryChangeListener(this, MicroProfileCorePlugin.PLUGIN_ID);
+		registryListenerIntialized = true;
+	}
+
+	public void destroy() {
+		Platform.getExtensionRegistry().removeRegistryChangeListener(this);
+	}
+
+	public void initialize() {
+
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ConfigSourceProviderRegistry.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ConfigSourceProviderRegistry.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core;
+
+import java.util.List;
+
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider;
+
+/**
+ * Registry to handle instances of IConfigSourceProvider
+ *
+ * @author datho7561
+ */
+public class ConfigSourceProviderRegistry extends AbstractMicroProfileProviderRegistry<IConfigSourceProvider> {
+
+	private static final ConfigSourceProviderRegistry INSTANCE = new ConfigSourceProviderRegistry();
+
+	private ConfigSourceProviderRegistry() {
+		super();
+	}
+
+	public static ConfigSourceProviderRegistry getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public String getProviderExtensionId() {
+		return "configSourceProviders";
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/PropertiesProviderRegistry.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/PropertiesProviderRegistry.java
@@ -34,120 +34,21 @@ import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
  * @author Angelo ZERR
  *
  */
-public class PropertiesProviderRegistry implements IRegistryChangeListener {
-
-	private static final String CLASS_ATTR = "class";
-
-	private static final Logger LOGGER = Logger.getLogger(PropertiesProviderRegistry.class.getName());
+public class PropertiesProviderRegistry extends AbstractMicroProfileProviderRegistry<IPropertiesProvider> {
 
 	private static final PropertiesProviderRegistry INSTANCE = new PropertiesProviderRegistry();
-
-	private static final String EXTENSION_PROPERTIES_PROVIDERS = "propertiesProviders";
 
 	public static PropertiesProviderRegistry getInstance() {
 		return INSTANCE;
 	}
 
-	private boolean extensionPropertiesProvidersLoaded;
-	private boolean registryListenerIntialized;
-	private final List<IPropertiesProvider> propertiesProviders;
-
-	public PropertiesProviderRegistry() {
+	private PropertiesProviderRegistry() {
 		super();
-		this.extensionPropertiesProvidersLoaded = false;
-		this.registryListenerIntialized = false;
-		this.propertiesProviders = new ArrayList<>();
-	}
-
-	/**
-	 * Returns the all properties providers.
-	 *
-	 * @return the all properties providers.
-	 */
-	public List<IPropertiesProvider> getPropertiesProviders() {
-		loadExtensionProviders();
-		return propertiesProviders;
-	}
-
-	private synchronized void loadExtensionProviders() {
-		if (extensionPropertiesProvidersLoaded)
-			return;
-
-		// Immediately set the flag, as to ensure that this method is never
-		// called twice
-		extensionPropertiesProvidersLoaded = true;
-
-		LOGGER.log(Level.INFO, "->- Loading .propertiesProviders extension point ->-");
-
-		IExtensionRegistry registry = Platform.getExtensionRegistry();
-		IConfigurationElement[] cf = registry.getConfigurationElementsFor(MicroProfileCorePlugin.PLUGIN_ID,
-				EXTENSION_PROPERTIES_PROVIDERS);
-		addExtensionPropertiesProviders(cf);
-		addRegistryListenerIfNeeded();
-
-		LOGGER.log(Level.INFO, "-<- Done loading .propertiesProviders extension point -<-");
 	}
 
 	@Override
-	public void registryChanged(final IRegistryChangeEvent event) {
-		IExtensionDelta[] deltas = event.getExtensionDeltas(MicroProfileCorePlugin.PLUGIN_ID,
-				EXTENSION_PROPERTIES_PROVIDERS);
-		if (deltas != null) {
-			synchronized (this) {
-				for (IExtensionDelta delta : deltas) {
-					IConfigurationElement[] cf = delta.getExtension().getConfigurationElements();
-					if (delta.getKind() == IExtensionDelta.ADDED) {
-						addExtensionPropertiesProviders(cf);
-					} else {
-						removeExtensionPropertiesProviders(cf);
-					}
-				}
-			}
-		}
+	public String getProviderExtensionId() {
+		return "propertiesProviders";
 	}
 
-	private void addExtensionPropertiesProviders(IConfigurationElement[] cf) {
-		for (IConfigurationElement ce : cf) {
-			try {
-				IPropertiesProvider provider = (IPropertiesProvider) ce.createExecutableExtension(CLASS_ATTR);
-				synchronized (propertiesProviders) {
-					propertiesProviders.add(provider);
-				}
-				LOGGER.log(Level.INFO, "  Loaded propertiesProviders: " + provider.getClass().getName());
-			} catch (Throwable t) {
-				LOGGER.log(Level.SEVERE, "  Loaded while loading  propertiesProviders", t);
-			}
-		}
-	}
-
-	private void removeExtensionPropertiesProviders(IConfigurationElement[] cf) {
-		for (IConfigurationElement ce : cf) {
-			try {
-				IPropertiesProvider provider = (IPropertiesProvider) ce.createExecutableExtension(CLASS_ATTR);
-				synchronized (propertiesProviders) {
-					propertiesProviders.remove(provider);
-				}
-				LOGGER.log(Level.INFO, "  Unloaded propertiesProviders: " + provider.getClass().getName());
-			} catch (Throwable t) {
-				LOGGER.log(Level.SEVERE, "  Unloaded while loading  propertiesProviders", t);
-			}
-		}
-	}
-
-	private void addRegistryListenerIfNeeded() {
-		if (registryListenerIntialized)
-			return;
-
-		IExtensionRegistry registry = Platform.getExtensionRegistry();
-		registry.addRegistryChangeListener(this, MicroProfileCorePlugin.PLUGIN_ID);
-		registryListenerIntialized = true;
-	}
-
-	public void destroy() {
-		Platform.getExtensionRegistry().removeRegistryChangeListener(this);
-	}
-
-	public void initialize() {
-
-	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/project/AbstractConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/project/AbstractConfigSource.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSource;
 import org.eclipse.lsp4mp.jdt.core.project.MicroProfileConfigPropertyInformation;
 
 /**

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/project/YamlConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/project/YamlConfigSource.java
@@ -112,4 +112,11 @@ public class YamlConfigSource extends AbstractConfigSource<Map<String, Object>> 
 		return result;
 	}
 
+	@Override
+	public int getOrdinal() {
+		// See https://github.com/quarkusio/quarkus/blob/main/extensions/config-yaml/runtime/src/main/java/io/quarkus/config/yaml/runtime/ApplicationYamlConfigSourceLoader.java#L29
+		// (or Quarkus --> yaml config extension --> ApplicationYamlConfigSourceLoader if the link is dead)
+		return 255;
+	}
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/providers/DefaultMicroProfilePropertiesConfigSourceProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/providers/DefaultMicroProfilePropertiesConfigSourceProvider.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core.providers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSource;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.core.project.PropertiesConfigSource;
+
+/**
+ * Provides the META-INF/microprofile-config.properties configuration source
+ *
+ * @author datho7561
+ */
+public class DefaultMicroProfilePropertiesConfigSourceProvider implements IConfigSourceProvider {
+
+	public static final String MICROPROFILE_CONFIG_PROPERTIES_FILE = "META-INF/microprofile-config.properties";
+
+	@Override
+	public List<IConfigSource> getConfigSources(IJavaProject project) {
+		return Arrays.asList(new PropertiesConfigSource(MICROPROFILE_CONFIG_PROPERTIES_FILE, project));
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/providers/QuarkusConfigSourceProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/providers/QuarkusConfigSourceProvider.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core.providers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSource;
+import org.eclipse.lsp4mp.jdt.core.project.IConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.core.project.PropertiesConfigSource;
+import org.eclipse.lsp4mp.jdt.internal.core.project.YamlConfigSource;
+
+/**
+ * Provides configuration sources specific to Quarkus
+ *
+ * This should be moved to quarkus-ls in the future
+ *
+ * @author datho7561
+ */
+@Deprecated
+public class QuarkusConfigSourceProvider implements IConfigSourceProvider {
+
+	public static final String APPLICATION_PROPERTIES_FILE = "application.properties";
+	public static final String APPLICATION_YAML_FILE = "application.yaml";
+	public static final String APPLICATION_YML_FILE = "application.yml";
+
+	@Override
+	public List<IConfigSource> getConfigSources(IJavaProject project) {
+		return Arrays.asList(new YamlConfigSource(APPLICATION_YAML_FILE, project),
+				new YamlConfigSource(APPLICATION_YML_FILE, project),
+				new PropertiesConfigSource(APPLICATION_PROPERTIES_FILE, project, 250));
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.site/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.3.1-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4mp.jdt.site</artifactId>
 	<packaging>eclipse-repository</packaging>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: quarkus.jdt.ls Test Plugin
 Bundle-SymbolicName: org.eclipse.lsp4mp.jdt.test
-Bundle-Version: 0.3.1.qualifier
+Bundle-Version: 0.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit,
  org.apache.commons.io,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>org.eclipse.lsp4mp</groupId>
-		<version>0.3.1-SNAPSHOT</version>
+		<version>0.4.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.eclipse.lsp4mp.jdt.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaDefinitionTest.java
@@ -28,6 +28,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.QuarkusConfigSourceProvider;
 import org.junit.After;
 import org.junit.Test;
 
@@ -42,9 +44,10 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 
 	@After
 	public void cleanup() throws JavaModelException, IOException {
-		deleteFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, javaProject);
-		deleteFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, javaProject);
-		deleteFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, javaProject);
+		deleteFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject);
 	}
 
 	@Test
@@ -57,7 +60,7 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
 				"greeting.message = hello\r\n" + //
 						"greeting.name = quarkus\r\n" + //
 						"greeting.number = 100",
@@ -99,6 +102,29 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 		// Position(23, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.missing")
 		assertJavaDefinitions(p(23, 33), javaFileUri, JDT_UTILS);
+
+	}
+
+	@Test
+	public void configPropertyNameDefinitionYml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile applicationYmlFile = project.getFile(new Path("src/main/resources/application.yml"));
+		String applicationYmlFileUri = fixURI(applicationYmlFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+				"  message: hello\n" + //
+				"  name: quarkus\n" + //
+				"  number: 100\n",
+				javaProject);
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaDefinitions(p(14, 40), javaFileUri, JDT_UTILS, //
+				def(r(14, 28, 44), applicationYmlFileUri, "greeting.message"));
 
 	}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaHoverTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/MicroProfileConfigJavaHoverTest.java
@@ -27,6 +27,8 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.QuarkusConfigSourceProvider;
 import org.junit.After;
 import org.junit.Test;
 
@@ -41,9 +43,10 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 
 	@After
 	public void cleanup() throws JavaModelException, IOException {
-		deleteFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, javaProject);
-		deleteFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, javaProject);
-		deleteFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, javaProject);
+		deleteFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, javaProject);
+		deleteFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, javaProject);
 	}
 
 	@Test
@@ -56,7 +59,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
 				"greeting.message = hello\r\n" + //
 						"greeting.name = quarkus\r\n" + //
 						"greeting.number = 100",
@@ -116,7 +119,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
 				"greeting.message = hello\r\n" + //
 						"%dev.greeting.message = hello dev\r\n" + //
 						"%prod.greeting.message = hello prod\r\n" + //
@@ -133,7 +136,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 						"`greeting.message = hello` *in* [application.properties](" + propertiesFileUri + ")", //
 						14, 28, 44));
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
 				"%dev.greeting.message = hello dev\r\n" + //
 						"%prod.greeting.message = hello prod\r\n" + //
 						"my.greeting.message\r\n" + //
@@ -162,13 +165,13 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
 				"greeting:\n" + //
 						"  message: message from yaml\n" + //
 						"  number: 2001",
 				javaProject);
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
 				"greeting.message = hello\r\n" + //
 						"greeting.name = quarkus\r\n" + //
 						"greeting.number = 100",
@@ -184,7 +187,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
 				h("`greeting.number = 2001` *in* [application.yaml](" + yamlFileUri + ")", 26, 28, 43));
 
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
 				"greeting:\n" + //
 						"  message: message from yaml",
 				javaProject);
@@ -203,7 +206,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "greeting.method.message = hello", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "greeting.method.message = hello", javaProject);
 
 		// Position(22, 61) is the character after the | symbol:
 		// @ConfigProperty(name = "greeting.m|ethod.message")
@@ -232,7 +235,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "greeting.constructor.message = hello",
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "greeting.constructor.message = hello",
 				javaProject);
 
 		// Position(23, 48) is the character after the | symbol:
@@ -264,13 +267,13 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
 
 		// microprofile-config.properties exists
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, "greeting.constructor.message = hello 1",
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, "greeting.constructor.message = hello 1",
 				javaProject);
 		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
 				h("`greeting.constructor.message = hello 1` *in* META-INF/microprofile-config.properties", 23, 36, 64));
 
 		// microprofile-config.properties and application.properties exist
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "greeting.constructor.message = hello 2",
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "greeting.constructor.message = hello 2",
 				javaProject);
 		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
 				h("`greeting.constructor.message = hello 2` *in* [application.properties](" + propertiesFileUri + ")",
@@ -278,7 +281,7 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 
 		// microprofile-config.properties, application.properties, and application.yaml
 		// exist
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
 				"greeting:\n" + //
 						"  constructor:\n" + //
 						"    message: hello 3", //
@@ -286,6 +289,49 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		assertJavaHover(new Position(23, 48), javaFileUri, JDT_UTILS,
 				h("`greeting.constructor.message = hello 3` *in* application.yaml", 23, 36, 64));
 
+	}
+
+	@Test
+	public void configPropertyNameYml() throws Exception {
+
+		javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = fixURI(javaFile.getLocation().toFile().toURI());
+		IFile ymlFile = project.getFile(new Path("src/main/resources/application.yml"));
+		String ymlFileUri = fixURI(ymlFile.getLocation().toFile().toURI());
+		IFile propertiesFile = project.getFile(new Path("src/main/resources/application.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yml\n" + //
+						"  number: 2001",
+				javaProject);
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, //
+				"greeting.message = hello\r\n" + //
+						"greeting.name = quarkus\r\n" + //
+						"greeting.number = 100",
+				javaProject);
+
+		// Position(14, 40) is the character after the | symbol:
+		// @ConfigProperty(name = "greeting.mes|sage")
+		assertJavaHover(new Position(14, 40), javaFileUri, JDT_UTILS,
+				h("`greeting.message = message from yml` *in* [application.yml](" + ymlFileUri + ")", 14, 28, 44));
+
+		// Position(26, 33) is the character after the | symbol:
+		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 2001` *in* [application.yml](" + ymlFileUri + ")", 26, 28, 43));
+
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YML_FILE, //
+				"greeting:\n" + //
+						"  message: message from yml",
+				javaProject);
+		// fallback to application.properties
+		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+				h("`greeting.number = 100` *in* [application.properties](" + propertiesFileUri + ")", 26, 28, 43));
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/JavaCodeLensMicroProfileRestClientTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/JavaCodeLensMicroProfileRestClientTest.java
@@ -27,6 +27,8 @@ import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
 import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider;
+import org.eclipse.lsp4mp.jdt.internal.core.providers.QuarkusConfigSourceProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -58,12 +60,12 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 		Assert.assertEquals(0, lenses.size());
 
 		// /mp-rest/url
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE,
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE,
 				"org.acme.restclient.CountriesService/mp-rest/url = https://restcountries.url/rest", javaProject);
 		assertCodeLenses("https://restcountries.url/rest", params, utils);
 
 		// /mp-rest/uri
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, //
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, //
 				"org.acme.restclient.CountriesService/mp-rest/uri = https://restcountries.uri/rest" + //
 						System.lineSeparator() + //
 						"org.acme.restclient.CountriesService/mp-rest/url = https://restcountries.url/rest", //
@@ -72,9 +74,9 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 	}
 
 	private static void initConfigFile(IJavaProject javaProject) throws JavaModelException, IOException {
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, "", javaProject);
-		saveFile(JDTMicroProfileProject.APPLICATION_PROPERTIES_FILE, "", javaProject);
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "", javaProject);
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_PROPERTIES_FILE, "", javaProject);
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "", javaProject);
 	}
 
 	@Test
@@ -96,13 +98,13 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 		assertCodeLenses("https://restcountries.ann/rest", params, utils);
 
 		// /mp-rest/url overrides @RegisterRestClient/baseUri
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE,
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE,
 				"org.acme.restclient.CountriesServiceWithBaseUri/mp-rest/url = https://restcountries.url/rest",
 				javaProject);
 		assertCodeLenses("https://restcountries.url/rest", params, utils);
 
 		// /mp-rest/uri overrides @RegisterRestClient/baseUri
-		saveFile(JDTMicroProfileProject.MICROPROFILE_CONFIG_PROPERTIES_FILE, //
+		saveFile(DefaultMicroProfilePropertiesConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE, //
 				"org.acme.restclient.CountriesServiceWithBaseUri/mp-rest/uri = https://restcountries.uri/rest" + //
 						System.lineSeparator() + //
 						"org.acme.restclient.CountriesServiceWithBaseUri/mp-rest/url = https://restcountries.url/rest", //
@@ -130,14 +132,14 @@ public class JavaCodeLensMicroProfileRestClientTest extends BasePropertiesManage
 		Assert.assertEquals(0, lenses.size());
 
 		// /mp-rest/url
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, "org:\r\n" + //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, "org:\r\n" + //
 				"  acme:\r\n" + //
 				"    restclient:\r\n" + //
 				"      CountriesService/mp-rest/url: https://restcountries.url/rest", javaProject);
 		assertCodeLenses("https://restcountries.url/rest", params, utils);
 
 		// /mp-rest/uri
-		saveFile(JDTMicroProfileProject.APPLICATION_YAML_FILE, //
+		saveFile(QuarkusConfigSourceProvider.APPLICATION_YAML_FILE, //
 				"org:\r\n" + //
 						"  acme:\r\n" + //
 						"    restclient:\r\n" + //

--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lsp4mp</groupId>
   <artifactId>parent</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>microprofile.jdt.ls :: parent</name>
   <description>microprofile.jdt.ls parent</description>

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lsp4mp</groupId>
 	<artifactId>org.eclipse.lsp4mp.ls</artifactId>
-	<version>0.3.1-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 
 	<name>MicroProfile Language Server</name>
 	<description>MicroProfile Language Server</description>


### PR DESCRIPTION
lsp4mp extensions can now contribute implementations of IConfigSourceProvider, which is a class that generates a list of IConfigSource given a project. All the IConfigSource generated by all the IConfigSourceProvider will be used for language features that use a property's value (eg. hover).

This means that if an implementation of MicroProfile provides a particular configuration file that is not a part of the base MicroProfile config, an extension to lsp4mp can be implemented which introduces support for the configuration file, without having to modify lsp4mp directly.

As example of how this can be used, this opens the door to moving the implementation and inclusion of the Quarkus `application.properties` and `application.yml` configuration sources out of lsp4mp, and instead providing them through a seperate project (quarkus-ls).

Signed-off-by: David Thompson <davthomp@redhat.com>
