### PR TITLE
Fix pom file versions that build failed to commit.

### DIFF
--- a/Release.Jenkinsfile
+++ b/Release.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
           sh '''
             git config --global user.email "lsp4mp-bot@eclipse.org"
             git config --global user.name "LSP4MP GitHub Bot"
-            git add **/pom.xml **/MANIFEST.MF
+            git add "**/pom.xml" "**/MANIFEST.MF"
             git commit -sm "Release $VERSION"
             git tag $VERSION
             git push origin $VERSION


### PR DESCRIPTION
- Build correctly adjusted pom files but failed to include them
- globbing provided to git-add should be quoted to prevent this

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>