### PR TITLE
Do not include fallback annotated method as its own fallback option

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/java/MicroProfileFaultToleranceCompletionParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/java/MicroProfileFaultToleranceCompletionParticipant.java
@@ -79,7 +79,9 @@ public class MicroProfileFaultToleranceCompletionParticipant implements IJavaCom
 		}
 		List<CompletionItem> completionItems = new ArrayList<>();
 		for (IMethod method : context.getTypeRoot().findPrimaryType().getMethods()) {
-			completionItems.add(makeMethodCompletionItem(method.getElementName(), range));
+			if (!method.equals(fallbackAnnotation.getParent())) {
+				completionItems.add(makeMethodCompletionItem(method.getElementName(), range));
+			}
 		}
 		return completionItems;
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaCompletionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/MicroProfileFaultToleranceJavaCompletionTest.java
@@ -47,7 +47,6 @@ public class MicroProfileFaultToleranceJavaCompletionTest extends BaseProperties
 		// fallbackMethod = "b|bb"
 		assertJavaCompletion(new MicroProfileJavaCompletionParams(javaFileUri, p(21, 33)), utils, //
 				c(te(21, 32, 21, 35, "hello"), "hello()", CompletionItemKind.Method), //
-				c(te(21, 32, 21, 35, "hi"), "hi()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "bbb"), "bbb()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "stringMethod"), "stringMethod()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "ccc"), "ccc()", CompletionItemKind.Method));
@@ -65,7 +64,6 @@ public class MicroProfileFaultToleranceJavaCompletionTest extends BaseProperties
 		// fallbackMethod = "|bbb"
 		assertJavaCompletion(new MicroProfileJavaCompletionParams(javaFileUri, p(21, 32)), utils, //
 				c(te(21, 32, 21, 35, "hello"), "hello()", CompletionItemKind.Method), //
-				c(te(21, 32, 21, 35, "hi"), "hi()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "bbb"), "bbb()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "stringMethod"), "stringMethod()", CompletionItemKind.Method), //
 				c(te(21, 32, 21, 35, "ccc"), "ccc()", CompletionItemKind.Method));
@@ -97,7 +95,6 @@ public class MicroProfileFaultToleranceJavaCompletionTest extends BaseProperties
 		assertJavaCompletion(new MicroProfileJavaCompletionParams(javaFileUri, p(28, 32)), utils, //
 				c(te(28, 32, 28, 32, "hello"), "hello()", CompletionItemKind.Method), //
 				c(te(28, 32, 28, 32, "hi"), "hi()", CompletionItemKind.Method), //
-				c(te(28, 32, 28, 32, "third"), "third()", CompletionItemKind.Method), //
 				c(te(28, 32, 28, 32, "fourth"), "fourth()", CompletionItemKind.Method), //
 				c(te(28, 32, 28, 32, "fifth"), "fifth()", CompletionItemKind.Method), //
 				c(te(28, 32, 28, 32, "aaa"), "aaa()", CompletionItemKind.Method));
@@ -116,7 +113,6 @@ public class MicroProfileFaultToleranceJavaCompletionTest extends BaseProperties
 				c(te(35, 30, 35, 30, "hello"), "hello()", CompletionItemKind.Method), //
 				c(te(35, 30, 35, 30, "hi"), "hi()", CompletionItemKind.Method), //
 				c(te(35, 30, 35, 30, "third"), "third()", CompletionItemKind.Method), //
-				c(te(35, 30, 35, 30, "fourth"), "fourth()", CompletionItemKind.Method), //
 				c(te(35, 30, 35, 30, "fifth"), "fifth()", CompletionItemKind.Method), //
 				c(te(35, 30, 35, 30, "aaa"), "aaa()", CompletionItemKind.Method));
 	}
@@ -135,7 +131,6 @@ public class MicroProfileFaultToleranceJavaCompletionTest extends BaseProperties
 				c(te(43, 9, 43, 9, "hi"), "hi()", CompletionItemKind.Method), //
 				c(te(43, 9, 43, 9, "third"), "third()", CompletionItemKind.Method), //
 				c(te(43, 9, 43, 9, "fourth"), "fourth()", CompletionItemKind.Method), //
-				c(te(43, 9, 43, 9, "fifth"), "fifth()", CompletionItemKind.Method), //
 				c(te(43, 9, 43, 9, "aaa"), "aaa()", CompletionItemKind.Method));
 	}
 


### PR DESCRIPTION
- Fixes #148
- Adjust tests accordingly

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>