### PR TITLE
Update eclipse-jarsigner-plugin

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -181,7 +181,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.4</version>
+						<version>1.3.2</version>
 						<executions>
 							<execution>
 								<id>sign</id>


### PR DESCRIPTION
The version of the jarsigner plugin that we are using tries to connect to build.eclipse.org, which is being phased out. This updated version should work with the new build infrastrucutre.

Signed-off-by: David Thompson <davthomp@redhat.com>
