### PR TITLE
added 'shouldLanguageServerExitOnShutdown' to ExtendedClientCapabilities

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileLanguageServer.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileLanguageServer.java
@@ -18,6 +18,9 @@ import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
 import static org.eclipse.lsp4mp.utils.VersionHelper.getVersion;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.eclipse.lsp4j.InitializeParams;
@@ -150,6 +153,10 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 
 	@Override
 	public CompletableFuture<Object> shutdown() {
+		if (capabilityManager.getClientCapabilities().getExtendedCapabilities().shouldLanguageServerExitOnShutdown()) {
+			ScheduledExecutorService delayer = Executors.newScheduledThreadPool(1);
+			delayer.schedule(() -> exit(0) , 1, TimeUnit.SECONDS);
+		}
 		return computeAsync(cc -> new Object());
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/ExtendedClientCapabilities.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/client/ExtendedClientCapabilities.java
@@ -24,6 +24,8 @@ public class ExtendedClientCapabilities {
 
 	private ExtendedCompletionCapabilities completion;
 
+	private boolean shouldLanguageServerExitOnShutdown;
+
 	public CommandCapabilities getCommands() {
 		return commands;
 	}
@@ -38,6 +40,26 @@ public class ExtendedClientCapabilities {
 
 	public void setCompletion(ExtendedCompletionCapabilities completion) {
 		this.completion = completion;
+	}
+
+	/**
+	 * Sets the boolean permitting language server to exit on client
+	 * shutdown() request, without waiting for client to call exit()
+	 *
+	 * @param shouldLanguageServerExitOnShutdown
+	 */
+	public void setShouldLanguageServerExitOnShutdown(boolean shouldLanguageServerExitOnShutdown) {
+		this.shouldLanguageServerExitOnShutdown = shouldLanguageServerExitOnShutdown;
+	}
+
+	/**
+	 * Returns true if the client should exit on shutdown() request and
+	 * avoid waiting for an exit() request
+	 *
+	 * @return true if the language server should exit on shutdown() request
+	 */
+	public boolean shouldLanguageServerExitOnShutdown() {
+		return shouldLanguageServerExitOnShutdown;
 	}
 
 }


### PR DESCRIPTION
lsp4mp support in ExtendedClientCapabilites for `shouldLanguageServerExitOnShutdown` capability on client side.

References redhat-developer/vscode-microprofile/pull/70

Signed-off-by: Alexander Chen alchen@redhat.com