### PR TITLE
added diagnostic(s) support for fault-tolerance Asynchronous annotation on type

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileConfigConstants.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileConfigConstants.java
@@ -54,4 +54,6 @@ public class MicroProfileConfigConstants {
 
 	public static final String DIAGNOSTIC_DATA_NAME = "name";
 
+	public static final String UNI_TYPE_UTILITY = "io.smallrye.mutiny.Uni";
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/acme/AsynchronousFaultToleranceClassResource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/acme/AsynchronousFaultToleranceClassResource.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+package org.acme;
+
+@Asynchronous
+public class AsynchronousFaultTolernaceResource {
+	
+    public Future<Object> futureAsynchronousMethod() {
+        return CompletableFuture.completedFuture(new Object());
+    }
+	     
+    public CompletionStage<Object> completionStageAsynchronousMethod() {
+        return CompletableFuture.completedFuture(new Object());
+    }
+	
+    public Object objectReturnTypeAsynchronousMethod() {
+    	return new Object();
+    }
+    
+    public void noReturnTypeAsynchronousMethod() {
+    	return;
+    }
+    
+    public CompletableFuture<Object> completableFutureAsynchronousMethod() {
+    	return CompletableFuture.completedFuture(new Object());
+    }
+    
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
@@ -55,7 +55,7 @@ public class MicroProfileFaultToleranceJavaDiagnosticsTest extends BasePropertie
 				MicroProfileFaultToleranceErrorCode.FALLBACK_METHOD_DOES_NOT_EXIST);
 		assertJavaDiagnostics(diagnosticsParams, utils, d);
 	}
-	
+
 	@Test
 	public void asynchronousNonFutureOrCompletionStage() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
@@ -67,27 +67,53 @@ public class MicroProfileFaultToleranceJavaDiagnosticsTest extends BasePropertie
 		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
 		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
 
-		Diagnostic d1 = d(34, 11, 17, 
-				"The annotated method does not return an object of type Future or CompletionStage", 
-				DiagnosticSeverity.Error,
-				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+		Diagnostic d1 = d(34, 11, 17,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
 				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
-		
-		Diagnostic d2 = d(39, 11, 15, 
-				"The annotated method does not return an object of type Future or CompletionStage", 
-				DiagnosticSeverity.Error,
-				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+
+		Diagnostic d2 = d(39, 11, 15,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
 				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
-		
-		Diagnostic d3 = d(44, 11, 36, 
-				"The annotated method does not return an object of type Future or CompletionStage", 
-				DiagnosticSeverity.Error,
-				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+
+		Diagnostic d3 = d(44, 11, 36,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
 				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
-		
+
 		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
 	}
-	
+
+	@Test
+	public void asynchronousClassNonFutureOrCompletionStage() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject()
+				.getFile(new Path("src/main/java/org/acme/AsynchronousFaultToleranceClassResource.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(32, 11, 17,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
+
+		Diagnostic d2 = d(36, 11, 15,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
+
+		Diagnostic d3 = d(40, 11, 36,
+				"The annotated method does not return an object of type Future, CompletionStage or Uni",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.FAULT_TOLERANCE_DEFINITION_EXCEPTION);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3);
+	}
+
 	@Test
 	public void fallbackMethodValidationFaultTolerant() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);


### PR DESCRIPTION
Added diagnostic(s) support for fault-tolerance Asynchronous annotation marked on type declaration.

Fixes #74

Signed-off-by: Alexander Chen <alchen@redhat.com>