### PR TITLE
Fix class cast exception

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigDiagnosticsParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigDiagnosticsParticipant.java
@@ -22,9 +22,7 @@ import static org.eclipse.lsp4mp.jdt.core.MicroProfileConfigConstants.MICRO_PROF
 import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.getAnnotationMemberValueExpression;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -55,6 +53,8 @@ import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProjectManager;
 import org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils;
 import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
 import org.eclipse.lsp4mp.jdt.internal.config.properties.MicroProfileConfigPropertyProvider;
+
+import com.google.gson.JsonObject;
 
 /**
  * Collects diagnostics related to the <code>@ConfigProperty</code> annotation
@@ -304,8 +304,8 @@ public class MicroProfileConfigDiagnosticsParticipant implements IJavaDiagnostic
 	}
 
 	public static void setDataForUnassigned(String name, Diagnostic diagnostic) {
-		Map<String, String> data = new HashMap<>();
-		data.put(DIAGNOSTIC_DATA_NAME, name);
+		JsonObject data = new JsonObject();
+		data.addProperty(DIAGNOSTIC_DATA_NAME, name);
 		diagnostic.setData(data);
 	}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/NoValueAssignedToPropertyQuickFix.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/NoValueAssignedToPropertyQuickFix.java
@@ -22,7 +22,6 @@ import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.getAnnotationMem
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -43,6 +42,9 @@ import org.eclipse.lsp4mp.jdt.core.project.IConfigSource;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProject;
 import org.eclipse.lsp4mp.jdt.core.project.JDTMicroProfileProjectManager;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * QuickFix for fixing
@@ -94,11 +96,10 @@ public class NoValueAssignedToPropertyQuickFix implements IJavaCodeActionPartici
 			throws JavaModelException {
 		if (diagnostic.getData() != null) {
 			// retrieve the property name from the diagnostic data
-			@SuppressWarnings("unchecked")
-			Map<String, String> data = (Map<String, String>) diagnostic.getData();
-			String name = data.get(DIAGNOSTIC_DATA_NAME);
+			JsonObject data = (JsonObject) diagnostic.getData();
+			JsonElement name = data.get(DIAGNOSTIC_DATA_NAME);
 			if (name != null) {
-				return name;
+				return name.getAsString();
 			}
 		}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtils.java
@@ -23,6 +23,9 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
 /**
  * Arguments utilities.
  *
@@ -107,7 +110,9 @@ public class ArgumentUtils {
 			diagnostic.setCode(getString(diagnosticObj, CODE_PROPERTY));
 			diagnostic.setMessage(getString(diagnosticObj, MESSAGE_PROPERTY));
 			diagnostic.setSource(getString(diagnosticObj, SOURCE_PROPERTY));
-			diagnostic.setData(getObject(diagnosticObj, DATA_PROPERTY));
+			// In Eclipse IDE (LSP client), the data is JsonObject, and in JDT-LS (ex : vscode as LSP client) the data is a Map, we
+			// convert the Map to a JsonObject to be consistent with any LSP clients.
+			diagnostic.setData(getObjectAsJson(diagnosticObj, DATA_PROPERTY));
 			return diagnostic;
 		}).collect(Collectors.toList());
 		List<String> only = null;
@@ -125,6 +130,15 @@ public class ArgumentUtils {
 		Object child = obj.get(key);
 		if (child != null && child instanceof Map<?, ?>) {
 			return (Map<String, Object>) child;
+		}
+		return null;
+	}
+
+	public static JsonObject getObjectAsJson(Map<String, Object> obj, String key) {
+		Object child = obj.get(key);
+		if (child != null && child instanceof Map<?, ?>) {
+			Gson gson = new Gson();
+			return (JsonObject) gson.toJsonTree(obj);
 		}
 		return null;
 	}


### PR DESCRIPTION
Since https://github.com/eclipse/lsp4mp/pull/167 we use `Diagnostic#data` to retrieve the config property name fromcode action which was computed on diagnostic step.

In vscode LSP client context (JDT LS) we use IDelegateCommandHandler which convert the JSONObject data in a Map. In Eclipse IDE context, the Diagnostic#data is a JsonObject and we have this problem:

```java
SEVERE: Error while calling getCodeActions
java.lang.ClassCastException: class com.google.gson.JsonObject cannot be cast to class java.util.Map (com.google.gson.JsonObject is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @27953fc0; java.util.Map is in module java.base of loader 'bootstrap')
	at org.eclipse.lsp4mp.jdt.internal.config.java.NoValueAssignedToPropertyQuickFix.getPropertyName(NoValueAssignedToPropertyQuickFix.java:98)
	at org.eclipse.lsp4mp.jdt.internal.config.java.NoValueAssignedToPropertyQuickFix.getCodeActions(NoValueAssignedToPropertyQuickFix.java:73)
	at org.eclipse.lsp4mp.jdt.internal.core.java.codeaction.JavaCodeActionDefinition.getCodeActions(JavaCodeActionDefinition.java:70)
	at org.eclipse.lsp4mp.jdt.internal.core.java.codeaction.CodeActionHandler.lambda$1(CodeActionHandler.java:129)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
	at org.eclipse.lsp4mp.jdt.internal.core.java.codeaction.CodeActionHandler.codeAction(CodeActionHandler.java:116)
```

This PR fixes this issue by assuming that we work in any context (any LSP clients) with JsonObject instead of Map.