### PR TITLE
added `@Bulkhead` and `@Timeout` non-negative diagnostic support

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -134,6 +134,17 @@
          <attribute name="failureRatio" range="[0,1]" /> <!-- 0 <= x <= 1 -->
          <attribute name="successThreshold" range="1" /> <!-- x >=1 -->         
       </annotationValidator>
+
+      <annotationValidator annotation="org.eclipse.microprofile.faulttolerance.Bulkhead"
+                   	       source="microprofile-faulttolerance" >
+         <attribute name="value" range="0" /> <!-- x >=0 -->
+         <attribute name="waitingTaskQueue" range="0" /> <!-- x >=0 -->
+      </annotationValidator>
+
+      <annotationValidator annotation="org.eclipse.microprofile.faulttolerance.Timeout"
+                           source="microprofile-faulttolerance" >
+         <attribute name="value" range="0" /> <!-- x >=0 -->
+      </annotationValidator>
    </extension>
 
    <!-- Microprofile LRA support -->

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/BulkheadClientForValidation.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/BulkheadClientForValidation.java
@@ -1,0 +1,84 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
+
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+
+/**
+ * A client to demonstrate the validation of the value on @Bulkhead
+ * 
+ * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
+ *
+ */
+ 
+public class BulkheadClientForValidation {
+
+    @Bulkhead(-1)
+    public Connection invalidA() {
+        return null;
+    }
+    
+    @Bulkhead(value=-1)
+    public Connection invalidB() {
+        return null;
+    }
+    
+    @Bulkhead(waitingTaskQueue=-1)
+    public Connection invalidC() {
+        return null;
+    }
+    
+    @Bulkhead(value=-1, waitingTaskQueue=-1)
+    public Connection invalidD() {
+        return null;
+    }
+    
+    @Bulkhead(value=-1, waitingTaskQueue=1)
+    public Connection invalidE() {
+        return null;
+    }
+    
+    @Bulkhead(value=1, waitingTaskQueue=-1)
+    public Connection invalidF() {
+        return null;
+    }
+    
+    @Bulkhead(1)
+    public Connection validA() {
+        return null;
+    }
+    
+    @Bulkhead(value=1)
+    public Connection validB() {
+        return null;
+    }
+    
+    @Bulkhead(waitingTaskQueue=1)
+    public Connection validC() {
+        return null;
+    }
+    
+    @Bulkhead(value=1, waitingTaskQueue=1)
+    public Connection validD() {
+        return null;
+    }
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/TimeoutClientForValidation.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/TimeoutClientForValidation.java
@@ -1,0 +1,53 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
+
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+/**
+ * A client to demonstrate the validation of the value on @Timeout
+ * 
+ * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
+ *
+ */
+public class TimeoutClientForValidation {
+
+    @Timeout(-1)
+    public Connection invalidA() {
+        return null;
+    }
+    
+    @Timeout(value=-1)
+    public Connection invalidB() {
+        return null;
+    }
+    
+    @Timeout(1)
+    public Connection validA() {
+        return null;
+    }
+    
+    @Timeout(value=1)
+    public Connection validB() {
+        return null;
+    }
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
@@ -147,4 +147,58 @@ public class MicroProfileFaultToleranceJavaDiagnosticsTest extends BasePropertie
 		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 	}
 
+	@Test
+	public void bulkheadClientForValidation() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path(
+				"src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/BulkheadClientForValidation.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(34, 14, 16, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d2 = d(39, 20, 22, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d3 = d(44, 31, 33, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d4_a = d(49, 20, 22, "The value `-1` must be greater than or equal to `0`.",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d4_b = d(49, 41, 43, "The value `-1` must be greater than or equal to `0`.",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d5 = d(54, 20, 22, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d6 = d(59, 40, 42, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4_a, d4_b, d5, d6);
+	}
+
+	@Test
+	public void timeoutClientForValidation() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path(
+				"src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/TimeoutClientForValidation.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(33, 13, 15, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d2 = d(38, 19, 21, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
+	}
 }


### PR DESCRIPTION
Added mp-fault-tolerance `@Bulkhead` and `@Timeout` non-negative value diagnostic support.

References #77 

Signed-off-by: Alexander Chen <alchen@redhat.com>

