### PR TITLE
added diagnostics support for `@Retry` annotation member values

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -2,14 +2,14 @@
 <?eclipse version="3.5"?>
 <plugin>
 
-   <extension-point id="propertiesProviders" 
+   <extension-point id="propertiesProviders"
 					name="%propertiesProviders.name"
 					schema="schema/propertiesProviders.exsd" />
-   <extension-point id="javaFeatureParticipants" 
+   <extension-point id="javaFeatureParticipants"
 					name="%javaFeatureParticipants.name"
 					schema="schema/javaFeatureParticipants.exsd" />
-   <extension-point id="projectLabelProviders" 
-                    name="%projectLabelProviders.name" 
+   <extension-point id="projectLabelProviders"
+                    name="%projectLabelProviders.name"
                     schema="schema/projectLabelProviders.exsd"/>
    <extension-point id="configSourceProviders"
                     name="%configSourceProviders.name"
@@ -58,7 +58,7 @@
       <provider class="org.eclipse.lsp4mp.jdt.internal.core.providers.DefaultMicroProfilePropertiesConfigSourceProvider" />
    </extension>
 
-   <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants" >      
+   <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants" >
       <!-- Diagnostics managed with Java AST vistor -->
    	  <diagnostics class="org.eclipse.lsp4mp.jdt.internal.core.java.validators.JavaASTDiagnosticsParticipant" />
    </extension>
@@ -77,14 +77,14 @@
       <!-- Properties provider from the MicroProfile @ConfigProperty annotation -->
       <provider class="org.eclipse.lsp4mp.jdt.internal.config.properties.MicroProfileConfigPropertyProvider" />
       <!-- Properties provider from the MicroProfile @ConfigProperties annotation -->
-      <provider class="org.eclipse.lsp4mp.jdt.internal.config.properties.MicroProfileConfigPropertiesProvider" />      
+      <provider class="org.eclipse.lsp4mp.jdt.internal.config.properties.MicroProfileConfigPropertiesProvider" />
    </extension>
 
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
       <!-- Java definition for the MicroProfile @ConfigProperty annotation -->
-      <definition class="org.eclipse.lsp4mp.jdt.internal.config.java.MicroProfileConfigDefinitionParticipant" />      
+      <definition class="org.eclipse.lsp4mp.jdt.internal.config.java.MicroProfileConfigDefinitionParticipant" />
       <!-- Java hover for the MicroProfile @ConfigProperty annotation -->
-      <hover class="org.eclipse.lsp4mp.jdt.internal.config.java.MicroProfileConfigHoverParticipant" />  
+      <hover class="org.eclipse.lsp4mp.jdt.internal.config.java.MicroProfileConfigHoverParticipant" />
       <!-- Java codeActions for MicroProfile @ConfigProperty -->
       <codeAction kind="quickfix"
                   targetDiagnostic="microprofile-config#NO_VALUE_ASSIGNED_TO_PROPERTY"
@@ -98,7 +98,7 @@
       <!-- Java validation for the MicroProfile @ConfigProperty annotation -->
       <validator class="org.eclipse.lsp4mp.jdt.internal.config.java.MicroProfileConfigASTValidator" />
    </extension>
-   
+
    <!-- Microprofile Context Propagation support -->
 
    <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">
@@ -112,10 +112,10 @@
       <!-- Properties provider from the MicroProfile Fault Tolerance annotations -->
       <provider class="org.eclipse.lsp4mp.jdt.internal.faulttolerance.properties.MicroProfileFaultToleranceProvider" />
    </extension>
-   
+
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants" >
       <!-- Java definition for the MicroProfile Fault Tolerance annotations -->
-      <definition class="org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceDefinitionParticipant" />         
+      <definition class="org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceDefinitionParticipant" />
    	  <!-- Completion for Fault Tolerance annotations -->s
    	  <completion class="org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceCompletionParticipant" />
    </extension>
@@ -132,7 +132,7 @@
          <attribute name="delay" range="0" /> <!-- x >=0 -->
          <attribute name="requestVolumeThreshold" range="1" /> <!-- x >=1 -->
          <attribute name="failureRatio" range="[0,1]" /> <!-- 0 <= x <= 1 -->
-         <attribute name="successThreshold" range="1" /> <!-- x >=1 -->         
+         <attribute name="successThreshold" range="1" /> <!-- x >=1 -->
       </annotationValidator>
 
       <annotationValidator annotation="org.eclipse.microprofile.faulttolerance.Bulkhead"
@@ -144,6 +144,14 @@
       <annotationValidator annotation="org.eclipse.microprofile.faulttolerance.Timeout"
                            source="microprofile-faulttolerance" >
          <attribute name="value" range="0" /> <!-- x >=0 -->
+      </annotationValidator>
+
+      <annotationValidator annotation="org.eclipse.microprofile.faulttolerance.Retry"
+                           source="microprofile-faulttolerance" >
+         <attribute name="delay" range="0" /> <!-- x >=0 -->
+         <attribute name="maxDuration" range="0" /> <!-- x >=0 -->
+         <attribute name="jitter" range="0" /> <!-- x >=0 -->
+         <attribute name="maxRetries" range="-1" /> <!-- x >=0 -->
       </annotationValidator>
    </extension>
 
@@ -169,12 +177,12 @@
                   targetDiagnostic="microprofile-metrics#ApplicationScopedAnnotationMissing"
                   class="org.eclipse.lsp4mp.jdt.internal.metrics.java.ApplicationScopedAnnotationMissingQuickFix" />
    </extension>
-   
+
    <!-- Microprofile OpenTracing support -->
 
    <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">
       <!-- Properties provider for MicroProfile OpenTracing -->
-      <provider class="org.eclipse.lsp4mp.jdt.internal.opentracing.properties.MicroProfileOpenTracingProvider" />     
+      <provider class="org.eclipse.lsp4mp.jdt.internal.opentracing.properties.MicroProfileOpenTracingProvider" />
    </extension>
 
    <!-- Microprofile OpenAPI support -->
@@ -186,7 +194,7 @@
 
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
       <!-- Java codeAction for generating MicroProfile OpenAPI annotations -->
-      <codeAction kind="source" 
+      <codeAction kind="source"
                   class="org.eclipse.lsp4mp.jdt.internal.openapi.java.MicroProfileGenerateOpenAPIOperation" />
    </extension>
 
@@ -196,14 +204,14 @@
       <!-- Properties provider for MicroProfile Health -->
       <provider class="org.eclipse.lsp4mp.jdt.internal.health.properties.MicroProfileHealthProvider" />
    </extension>
-   
+
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
       <!-- Java diagnostics for the MicroProfile Health -->
       <diagnostics class="org.eclipse.lsp4mp.jdt.internal.health.java.MicroProfileHealthDiagnosticsParticipant" />
       <!-- Java codeActions for the MicroProfile Health -->
       <codeAction kind="quickfix"
                   targetDiagnostic="microprofile-health#ImplementHealthCheck"
-                  class="org.eclipse.lsp4mp.jdt.internal.health.java.ImplementHealthCheckQuickFix" />   
+                  class="org.eclipse.lsp4mp.jdt.internal.health.java.ImplementHealthCheckQuickFix" />
       <codeAction kind="quickfix"
                   targetDiagnostic="microprofile-health#HealthAnnotationMissing"
                   class="org.eclipse.lsp4mp.jdt.internal.health.java.HealthAnnotationMissingQuickFix" />
@@ -224,7 +232,7 @@
    </extension>
 
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
-      <!-- Java URL codeLens for RestClient -->   
+      <!-- Java URL codeLens for RestClient -->
       <codeLens class="org.eclipse.lsp4mp.jdt.internal.restclient.java.MicroProfileRestClientCodeLensParticipant" />
       <!-- Java diagnostics for the MicroProfile RestClient -->
       <diagnostics class="org.eclipse.lsp4mp.jdt.internal.restclient.java.MicroProfileRestClientDiagnosticsParticipant" />
@@ -248,10 +256,10 @@
    <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">
       <!-- Properties provider for MicroProfile JWT -->
       <provider class="org.eclipse.lsp4mp.jdt.internal.jwt.properties.MicroProfileJWTProvider" />
-   </extension> 
+   </extension>
 
     <!-- MicroProfile GraphQL Support -->
-   
+
    <extension point="org.eclipse.lsp4mp.jdt.core.propertiesProviders">
       <!-- Properties provider for MicroProfile GraphQL -->
       <provider class="org.eclipse.lsp4mp.jdt.internal.graphql.properties.MicroProfileGraphQLProvider" />
@@ -261,6 +269,6 @@
 
    <extension point="org.eclipse.lsp4mp.jdt.core.javaFeatureParticipants">
       <!-- Java URL codeLens for JAX-RS -->
-      <codeLens class="org.eclipse.lsp4mp.jdt.internal.jaxrs.java.JaxRsCodeLensParticipant" />   
+      <codeLens class="org.eclipse.lsp4mp.jdt.internal.jaxrs.java.JaxRsCodeLensParticipant" />
    </extension>
 </plugin>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/annotations/RangeExpression.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/annotations/RangeExpression.java
@@ -19,9 +19,9 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * The range expression used to validate value from an attribute annotation.
- * 
+ *
  * The range is specified like OSGi version syntax:
- * 
+ *
  * <ul>
  * <li>0 -> means >=0</li>
  * <li>[0 -> means >=0</li>
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
  * <li>(0,1) -> means >0 && <1</li>
  * <li>[0,1) -> means >=0 && <1</li>
  * </ul>
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -91,7 +91,7 @@ public class RangeExpression {
 
 	/**
 	 * Parse the given range <code>expression</code>.
-	 * 
+	 *
 	 * @param expression the range expression to parse.
 	 * @return an instance of range expression.
 	 * @throws RangeExpressionException thrown when expression doesn't respect the
@@ -151,11 +151,19 @@ public class RangeExpression {
 				}
 				valueAsString.append(c);
 				break;
+			case '-':
+				if (valueAsString.length() == 0) {
+					valueAsString.append(c);
+				} else {
+					unexpectedToken(c, i, expression);
+				}
+				break;
 			default:
 				if (Character.isDigit(c)) {
 					valueAsString.append(c);
 				} else {
 					unexpectedToken(c, i, expression);
+					break;
 				}
 			}
 		}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/MicroProfileFaultToleranceConstants.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/MicroProfileFaultToleranceConstants.java
@@ -42,6 +42,18 @@ public class MicroProfileFaultToleranceConstants {
 
 	public static final String FALLBACK_METHOD_FALLBACK_ANNOTATION_MEMBER = "fallbackMethod";
 
+	public static final String DELAY_RETRY_ANNOTATION_MEMBER = "delay";
+
+	public static final String DELAY_UNIT_RETRY_ANNOTATION_MEMBER = "delayUnit";
+
+	public static final String MAX_DURATION_RETRY_ANNOTATION_MEMBER = "maxDuration";
+
+	public static final String DURATION_UNIT_RETRY_ANNOTATION_MEMBER = "durationUnit";
+
+	public static final String JITTER_RETRY_ANNOTATION_MEMBER = "jitter";
+
+	public static final String JITTER_DELAY_UNIT_RETRY_ANNOTATION_MEMBER = "jitterDelayUnit";
+
 	// MP_Fault_Tolerance_NonFallback_Enabled
 
 	public static final String MP_FAULT_TOLERANCE_NON_FALLBACK_ENABLED = "MP_Fault_Tolerance_NonFallback_Enabled";

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/java/MicroProfileFaultToleranceErrorCode.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/faulttolerance/java/MicroProfileFaultToleranceErrorCode.java
@@ -17,8 +17,7 @@ import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaErrorCode;
 
 public enum MicroProfileFaultToleranceErrorCode implements IJavaErrorCode {
 
-	FALLBACK_METHOD_DOES_NOT_EXIST, 
-	FAULT_TOLERANCE_DEFINITION_EXCEPTION;
+	FALLBACK_METHOD_DOES_NOT_EXIST, FAULT_TOLERANCE_DEFINITION_EXCEPTION, DELAY_EXCEEDS_MAX_DURATION;
 
 	@Override
 	public String getCode() {

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidation.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidation.java
@@ -1,0 +1,88 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
+
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * A client to demonstrate the validation of @Retry
+ * 
+ * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
+ *
+ */
+public class RetryClientForValidation {
+
+    @Retry(delay = -1)
+    public Connection invalidA() {
+        return null;
+    }
+    
+    @Retry(maxDuration = -1)
+    public Connection invalidB() {
+        return null;
+    }
+    
+    @Retry(jitter = -1)
+    public Connection invalidC() {
+        return null;
+    }
+    
+    @Retry(maxRetries = -2)
+    public Connection invalidD() {
+        return null;
+    }
+    
+    @Retry(delay = 1000, maxDuration = 500)
+    public Connection invalidE() {
+        return null;
+    }
+    
+    @Retry(delay = 1000, maxDuration = 1000)
+    public Connection invalidF() {
+        return null;
+    }
+    
+    @Retry(delay = 1)
+    public Connection validA() {
+        return null;
+    }
+    
+    @Retry(maxDuration = 1)
+    public Connection validB() {
+        return null;
+    }
+    
+    @Retry(jitter = 1)
+    public Connection validC() {
+        return null;
+    }
+    
+    @Retry(maxRetries = 1)
+    public Connection validD() {
+        return null;
+    }
+    
+    @Retry(delay = 1000, maxDuration = 5000)
+    public Connection validE() {
+        return null;
+    }
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationClass.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationClass.java
@@ -1,0 +1,50 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
+
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * A client to demonstrate the validation of @Retry on class
+ * 
+ * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
+ *
+ */
+
+@Retry(delay = -2, maxDuration = -1, jitter = -1, maxRetries = -2)
+public class RetryClientForValidationClass {
+
+    public Connection methodA() {
+        return null;
+    }
+    
+    @Retry(delay = 1000, maxDuration = 500)
+    public Connection overrideInvalid() {
+        return null;
+    }
+    
+    @Retry(delay = 100, maxDuration = 500, jitter = 1, maxRetries = 1)
+    public Connection overrideValid() {
+        return null;
+    }
+    
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
@@ -201,4 +201,69 @@ public class MicroProfileFaultToleranceJavaDiagnosticsTest extends BasePropertie
 
 		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2);
 	}
+
+	@Test
+	public void retryClientForValidation() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path(
+				"src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidation.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(33, 19, 21, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d2 = d(38, 25, 27, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d3 = d(43, 20, 22, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d4 = d(48, 24, 26, "The value `-2` must be greater than or equal to `-1`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d5 = d(53, 19, 23, "The `delay` member value must be less than the `maxDuration` member value.",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		Diagnostic d6 = d(58, 19, 23, "The `delay` member value must be less than the `maxDuration` member value.",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5, d6);
+	}
+
+	@Test
+	public void retryClientForValidationClass() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path(
+				"src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationClass.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(32, 15, 17, "The value `-2` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d2 = d(32, 33, 35, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d3 = d(32, 46, 48, "The value `-1` must be greater than or equal to `0`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d4 = d(32, 63, 65, "The value `-2` must be greater than or equal to `-1`.", DiagnosticSeverity.Error,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE, null);
+
+		Diagnostic d5 = d(39, 19, 23, "The `delay` member value must be less than the `maxDuration` member value.",
+				DiagnosticSeverity.Error, MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
+	}
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/annotations/AnnotationValidatorTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/annotations/AnnotationValidatorTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 /**
  * Test for annotation based on rules.
- * 
+ *
  * @author Angelo ZERR
  *
  */
@@ -45,6 +45,14 @@ public class AnnotationValidatorTest {
 		assertValidation("[0", "0", null);
 		assertValidation("[0", "1", null);
 		assertValidation("[0", "-1", "The value `-1` must be greater than or equal to `0`.");
+	}
+
+	@Test
+	public void testGreaterThanOrEqualWithNegativeValue() throws RangeExpressionException {
+		assertValidation("-1", "0", null);
+		assertValidation("-1", "1", null);
+		assertValidation("-1", "-1", null);
+		assertValidation("-1", "-2", "The value `-2` must be greater than or equal to `-1`.");
 	}
 
 	@Test


### PR DESCRIPTION
Added diagnostics support for `@Retry` annotation member values, for non-negative values and `delay` exceeding `maxDuration`

References #77 

Signed-off-by: Alexander Chen <alchen@redhat.com>