### PR TITLE
added diagnostic for `@ConfigProperty` name member as empty string

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigASTValidator.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigASTValidator.java
@@ -74,6 +74,8 @@ public class MicroProfileConfigASTValidator extends JavaASTValidator {
 
 	private static final String NO_VALUE_ERROR_MESSAGE = "The property ''{0}'' is not assigned a value in any config file, and must be assigned at runtime.";
 
+	private static final String EMPTY_KEY_ERROR_MESSAGE = "The member ''{0}'' can'''t be empty.";
+
 	private List<String> patterns;
 	// prefix from @ConfigProperties(prefix="")
 	private String currentPrefix;
@@ -187,12 +189,17 @@ public class MicroProfileConfigASTValidator extends JavaASTValidator {
 				name = MicroProfileConfigPropertyProvider.getPropertyName(name, currentPrefix);
 			}
 
-			if (name != null && !hasDefaultValue && !doesPropertyHaveValue(name, getContext())
-					&& !isPropertyIgnored(name)) {
-				String message = MessageFormat.format(NO_VALUE_ERROR_MESSAGE, name);
-				Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
-						MicroProfileConfigErrorCode.NO_VALUE_ASSIGNED_TO_PROPERTY, DiagnosticSeverity.Warning);
-				setDataForUnassigned(name, d);
+			if (name != null) {
+				if (name.isEmpty()) {
+					String message = MessageFormat.format(EMPTY_KEY_ERROR_MESSAGE, CONFIG_PROPERTY_ANNOTATION_NAME);
+					Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
+							MicroProfileConfigErrorCode.EMPTY_KEY, DiagnosticSeverity.Error);
+				} else if (!hasDefaultValue && !doesPropertyHaveValue(name, getContext()) && !isPropertyIgnored(name)) {
+					String message = MessageFormat.format(NO_VALUE_ERROR_MESSAGE, name);
+					Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
+							MicroProfileConfigErrorCode.NO_VALUE_ASSIGNED_TO_PROPERTY, DiagnosticSeverity.Warning);
+					setDataForUnassigned(name, d);
+				}
 			}
 		} catch (JavaModelException e) {
 			LOGGER.log(Level.WARNING,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigErrorCode.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigErrorCode.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaErrorCode;
  */
 public enum MicroProfileConfigErrorCode implements IJavaErrorCode {
 
-	NO_VALUE_ASSIGNED_TO_PROPERTY, DEFAULT_VALUE_IS_WRONG_TYPE;
+	NO_VALUE_ASSIGNED_TO_PROPERTY, DEFAULT_VALUE_IS_WRONG_TYPE, EMPTY_KEY;
 
 	@Override
 	public String getCode() {

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-configproperties/src/main/java/org/acme/EmptyKey.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-configproperties/src/main/java/org/acme/EmptyKey.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+public class EmptyKey {
+
+    @ConfigProperty(name="")
+    private String bar;
+    
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
@@ -196,6 +196,23 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 
 	}
 
+	@Test
+	public void emptyNameKeyValue() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_configproperties);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path("src/main/java/org/acme/EmptyKey.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(5, 25, 27, "The member 'name' can't be empty.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.EMPTY_KEY);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1);
+	}
+
 	private static String fixURI(String uriString) {
 		return uriString.replaceFirst("file:/([^/])", "file:///$1");
 	}


### PR DESCRIPTION
Added diagnostic for `@ConfigProperty` name member as empty string to handle `name=""` case.

Fixes #176 

Signed-off-by: Alexander Chen <alchen@redhat.com>