### PR TITLE
removed Duration class from `@Retry` annotation and supported date based `ChronoUnit`

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationChronoUnit.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-fault-tolerance/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationChronoUnit.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2021 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
+
+import java.sql.Connection;
+import java.time.temporal.ChronoUnit;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@Retry(delay = 1, maxDuration = 24, delayUnit = java.time.temporal.ChronoUnit.DAYS, durationUnit = HOURS)
+public class RetryClientForValidationChronoUnit {
+
+	@Retry(delay = 1, maxDuration = 61, delayUnit = ChronoUnit.HOURS, durationUnit = MINUTES)
+    public Connection validA() {
+        return null;
+    }
+	
+    @Retry(delay = 1, maxDuration = 367, delayUnit = java.time.temporal.ChronoUnit.YEARS, durationUnit = ChronoUnit.DAYS)
+    public Connection validB() {
+        return null;
+    }
+    
+    @Retry(delay = 30, jitter = 29, maxDuration = 1, delayUnit = ChronoUnit.MINUTES, jitterDelayUnit = ChronoUnit.MINUTES, durationUnit = ChronoUnit.HOURS)
+    public Connection validC() {
+        return null;
+    }
+	
+    @Retry(delay = 1, maxDuration = 60, delayUnit = ChronoUnit.HOURS, durationUnit = MINUTES)
+    public Connection invalidA() {
+        return null;
+    }
+
+    @Retry(delay = 1, maxDuration = 365, delayUnit = java.time.temporal.ChronoUnit.YEARS, durationUnit = ChronoUnit.DAYS)
+    public Connection invalidB() {
+        return null;
+    }
+
+    @Retry(delay = 30, jitter = 30, maxDuration = 1, delayUnit = ChronoUnit.MINUTES, jitterDelayUnit = ChronoUnit.MINUTES, durationUnit = ChronoUnit.HOURS)
+    public Connection invalidC() {
+        return null;
+    }
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/java/MicroProfileFaultToleranceJavaDiagnosticsTest.java
@@ -339,4 +339,44 @@ public class MicroProfileFaultToleranceJavaDiagnosticsTest
 		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4, d5);
 	}
 
+	@Test
+	public void retryClientForValidationChronoUnit() throws Exception {
+		IJavaProject javaProject = loadMavenProject(
+				MicroProfileMavenProjectName.microprofile_fault_tolerance);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject().getFile(new Path(
+				"src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/RetryClientForValidationChronoUnit.java"));
+		diagnosticsParams.setUris(Arrays
+				.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(24, 15, 16,
+				"The effective delay may exceed the `maxDuration` member value.",
+				DiagnosticSeverity.Warning,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		Diagnostic d2 = d(42, 19, 20,
+				"The effective delay may exceed the `maxDuration` member value.",
+				DiagnosticSeverity.Warning,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		Diagnostic d3 = d(47, 19, 20,
+				"The effective delay may exceed the `maxDuration` member value.",
+				DiagnosticSeverity.Warning,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		Diagnostic d4 = d(52, 19, 21,
+				"The effective delay may exceed the `maxDuration` member value.",
+				DiagnosticSeverity.Warning,
+				MicroProfileFaultToleranceConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileFaultToleranceErrorCode.DELAY_EXCEEDS_MAX_DURATION);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, d1, d2, d3, d4);
+	}
+
 }


### PR DESCRIPTION
Removed `Duration` class from `@Retry` annotation and supported date based `ChronoUnit` enumeration(s)

Fixes: #196 

Signed-off-by: Alexander Chen <alchen@redhat.com>