### PR TITLE
Do not rebuild list of configuration properties when MicroProfile config sources are updated in the build directory

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -122,7 +123,11 @@ public class PropertiesManager {
 			LOGGER.info("Start computing MicroProfile properties for '" + info.getProjectURI() + "' project.");
 		}
 		SubMonitor mainMonitor = SubMonitor.convert(monitor,
-				"Scanning properties for '" + javaProject.getProject().getName() + "' project", 100);
+				"Scanning properties for '" + javaProject.getProject().getName() + "' project in '" + scopes.stream() //
+						.map(MicroProfilePropertiesScope::name) //
+						.collect(Collectors.joining("+")) //
+						+ "'",
+				100);
 		try {
 			boolean excludeTestCode = classpathKind == ClasspathKind.SRC;
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/java/JavaFileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/java/JavaFileTextDocumentService.java
@@ -370,6 +370,9 @@ public class JavaFileTextDocumentService extends AbstractTextDocumentService {
 
 	public void propertiesChanged(MicroProfilePropertiesChangeEvent event) {
 		if (documents.propertiesChanged(event) || MicroProfilePropertiesScope.isOnlyConfigFiles(event.getType())) {
+			// Classpath changed or some properties config files (ex :
+			// microprofile-config.properties) has been
+			// saved, revalidate all opened java files.
 			triggerValidationForAll(null);
 		}
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/MicroProfileProjectInfoCache.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/MicroProfileProjectInfoCache.java
@@ -14,6 +14,7 @@
 package org.eclipse.lsp4mp.ls.properties;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -113,10 +114,19 @@ class MicroProfileProjectInfoCache {
 
 	public Collection<String> propertiesChanged(MicroProfilePropertiesChangeEvent event) {
 		List<MicroProfilePropertiesScope> scopes = event.getType();
+		if (MicroProfilePropertiesScope.isOnlyConfigFiles(scopes)) {
+			// Some properties config files (ex : microprofile-config.properties) has been
+			// saved, ignore this event.
+			return Collections.emptyList();
+		}
 		boolean changedOnlyInSources = MicroProfilePropertiesScope.isOnlySources(scopes);
 		if (changedOnlyInSources) {
+			// Some Java sources files has been saved, evict the cache for item metadata
+			// (properties) computed from Java source files only.
 			return javaSourceChanged(event.getProjectURIs());
 		}
+		// Classpath changed (ex : add, remove maven/gradle dependencies) evict the full
+		// cache.
 		return classpathChanged(event.getProjectURIs());
 	}
 


### PR DESCRIPTION
Do not rebuild list of configuration properties when MicroProfile config sources are updated in the build directory

Fixes #162

Signed-off-by: azerr <azerr@redhat.com>