### PR TITLE
Update o.e.jdt.ls.tp dependency to 1.7.0 Release

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -10,11 +10,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.2.0</tycho.version>
+    <tycho.version>2.5.0</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.5.0.20211019160210</jdt.ls.version>
+    <jdt.ls.version>1.7.0.20211216164144</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 


### PR DESCRIPTION
- Also update Tycho to 2.5.0

See https://ci.eclipse.org/lsp4mp/job/lsp4mp/job/master/127/console . Need the same change as https://github.com/redhat-developer/quarkus-ls/pull/529

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>