### PR TITLE
Ignored ENV reference in expression validation

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileValidator.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4mp.model.PropertiesModel;
 import org.eclipse.lsp4mp.model.Property;
 import org.eclipse.lsp4mp.model.PropertyValueExpression;
 import org.eclipse.lsp4mp.settings.MicroProfileValidationSettings;
+import org.eclipse.lsp4mp.utils.EnvUtils;
 import org.eclipse.lsp4mp.utils.PositionUtils;
 import org.eclipse.lsp4mp.utils.PropertiesFileUtils;
 
@@ -240,20 +241,21 @@ class PropertiesFileValidator {
 							}
 						} else {
 							if (propValExpr.hasDefaultValue()) {
+								// The expression has default value (ex : ${DBUSER:sa})
 								int start = propValExpr.getDefaultValueStartOffset();
 								int end = propValExpr.getDefaultValueEndOffset();
 								validatePropertyValue(propertyName, metadata, propValExpr.getDefaultValue(), start, end,
 									propValExpr.getOwnerModel());
 							} else {
-								// The expression has default value (ex : ${DBUSER:sa}) otherwise the error
-								// is reported
-								Range range = PositionUtils.createRange(propValExpr.getReferenceStartOffset(),
-									propValExpr.getReferenceEndOffset(), propValExpr.getDocument());
-								if (range != null) {
-									addDiagnostic("Unknown referenced property value expression '" + refdProp + "'",
-										range, expressionSeverity, ValidationType.expression.name());
-								} else {
-
+								if (!(EnvUtils.isEnvVariable(refdProp))) {
+									// or the expression is an ENV variable
+									// otherwise the error is reported
+									Range range = PositionUtils.createRange(propValExpr.getReferenceStartOffset(),
+										propValExpr.getReferenceEndOffset(), propValExpr.getDocument());
+									if (range != null) {
+										addDiagnostic("Unknown referenced property value expression '" + refdProp + "'",
+											range, expressionSeverity, ValidationType.expression.name());
+									}
 								}
 							}
 						}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/utils/EnvUtils.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/utils/EnvUtils.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.utils;
+
+/**
+ * Environment variable utility class
+ *
+ */
+public class EnvUtils {
+	/**
+	 * Return true if the variable is an ENV variable, and false otherwise
+	 *
+	 * @param variable the variable to check
+	 * @return true if the variable is an ENV variable, and false otherwise
+	 */
+	public static boolean isEnvVariable(String variable) {
+		char[] chars = variable.toCharArray();
+		for (char c : chars) {
+			if (!Character.isUpperCase(c) && Character.isLetter(c)) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionDiagnosticsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionDiagnosticsTest.java
@@ -104,10 +104,33 @@ public class PropertiesFileExpressionDiagnosticsTest {
 	public void ignoreErrorForPropertyExpressionWithDefaultValue() {
 		String value = "quarkus.datasource.username = ${DBUSER:sa}";
 		testDiagnosticsFor(value);
+	}
+
+	@Test
+	public void ignoreErrorForEnvPropertyExpressionWithoutDefaultValue() {
+		String value = "quarkus.datasource.username = ${DBUSER}";
+		testDiagnosticsFor(value);
 
 		value = "quarkus.datasource.username = ${DBUSER:}";
+		testDiagnosticsFor(value);
+	}
+
+	@Test
+	public void throwErrorForNonEnvPropertyExpressionWithDefaultValue() {
+		String value = "quarkus.datasource.username = ${dbuser:sa}";
+		testDiagnosticsFor(value);
+	}
+
+	@Test
+	public void throwErrorForNonEnvPropertyExpressionWithoutDefaultValue() {
+		String value = "quarkus.datasource.username = ${dbuser}";
 		testDiagnosticsFor(value, //
-			d(0, 32, 38, "Unknown referenced property value expression 'DBUSER'", DiagnosticSeverity.Error,
+			d(0, 32, 38, "Unknown referenced property value expression 'dbuser'", DiagnosticSeverity.Error,
+				ValidationType.expression));
+
+		value = "quarkus.datasource.username = ${dbuser:}";
+		testDiagnosticsFor(value, //
+			d(0, 32, 38, "Unknown referenced property value expression 'dbuser'", DiagnosticSeverity.Error,
 				ValidationType.expression));
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/utils/EnvUtilsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/utils/EnvUtilsTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EnvUtils}.
+ *
+ */
+public class EnvUtilsTest {
+
+	@Test
+	public void wellFormedEnv() {
+		String envVar = "ENV";
+		Assert.assertTrue(EnvUtils.isEnvVariable(envVar));
+	}
+
+	@Test
+	public void wellFormedEnvUnderscore() {
+		String envVar = "ENV_A";
+		Assert.assertTrue(EnvUtils.isEnvVariable(envVar));
+	}
+
+	@Test
+	public void wellFormedEnvDigit() {
+		String envVar = "ENV1";
+		Assert.assertTrue(EnvUtils.isEnvVariable(envVar));
+	}
+
+	@Test
+	public void malFormedEnvLowerCase() {
+		String envVar = "env";
+		Assert.assertFalse(EnvUtils.isEnvVariable(envVar));
+	}
+
+	@Test
+	public void malFormedEnvMixedCase() {
+		String envVar = "eNV";
+		Assert.assertFalse(EnvUtils.isEnvVariable(envVar));
+	}
+
+}


### PR DESCRIPTION
Ignored ENV reference for expression validation without the addition of a default value.
![Screenshot from 2022-06-02 10-19-21](https://user-images.githubusercontent.com/26389510/171651684-5b83b5ed-a8c7-4441-81a4-f8d36a566904.png)


Fixes #227 

Signed-off-by: Alexander Chen <alchen@redhat.com>