### PR TITLE
Temporarily use JDT-LS 1.12.0 (instead of SNAPSHOT build)

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -41,7 +41,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.12.0/repository/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>


### PR DESCRIPTION
- Eventually a proper update to Java 17 will be required

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>