### PR TITLE
Remove unnecessary 2019-06 release repository from target platform.

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.5.0</tycho.version>
+    <tycho.version>2.7.2</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
@@ -33,11 +33,6 @@
 		<tag>${project.version}</tag>
 	</scm>
   <repositories>
-    <repository>
-      <id>2019-06</id>
-      <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/2019-06</url>
-    </repository>
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>


### PR DESCRIPTION
- Update Tycho to 2.7.2
- Dependencies from the JDT-LS target (artifact) file are sufficient

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>