### PR TITLE
Update Gradle test project versions to 7.3

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/empty-gradle-project/gradle/wrapper/gradle-wrapper.properties
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/empty-gradle-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/quarkus-gradle-project/gradle/wrapper/gradle-wrapper.properties
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/quarkus-gradle-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/renamed-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/gradle/renamed-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Gradle 7.3 is the first version compatible with Java 17

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>