### PR TITLE
Fix NPE when hovering in properties file

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
@@ -148,7 +148,7 @@ public class PropertiesFileTextDocumentService extends AbstractTextDocumentServi
 			MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 			MicroProfileProjectInfo projectInfo = getProjectInfoCache().getProjectInfo(projectInfoParams).getNow(null);
 			if (projectInfo == null || projectInfo.getProperties().isEmpty()) {
-				return new Hover();
+				return null;
 			}
 			cancelChecker.checkCanceled();
 


### PR DESCRIPTION
lsp4j does not support serializing `Hover` without `contents`, so return null instead of a blank hover.

Closes #265

Signed-off-by: David Thompson <davthomp@redhat.com>
