### PR TITLE
Remove unnecessary Gson dependency in pom file.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
@@ -13,11 +13,4 @@
 	<name>MicroProfile JDT LS Extension</name>
 	<description>MicroProfile JDT LS Extension - Core</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.5</version>
-		</dependency>
-	</dependencies>
 </project>


### PR DESCRIPTION
- com.google.gson will come from the o.e.jdt.ls.tp target so there is no
  need to specify it as a dependency in the pom

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>