### PR TITLE
Fix for excessive property definition display on hover

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/java/JavaFileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/java/JavaFileTextDocumentService.java
@@ -152,8 +152,7 @@ public class JavaFileTextDocumentService extends AbstractTextDocumentService {
 				return null;
 			}
 			boolean canSupportMarkdown = true;
-			boolean snippetsSupported = sharedSettings.getCompletionCapabilities()
-					.isCompletionSnippetsSupported();
+			boolean snippetsSupported = sharedSettings.getCompletionCapabilities().isCompletionSnippetsSupported();
 			CompletionList list1 = new CompletionList();
 			list1.setItems(new ArrayList<>());
 			documents.getSnippetRegistry().getCompletionItems(document, completionOffset, canSupportMarkdown,
@@ -290,8 +289,9 @@ public class JavaFileTextDocumentService extends AbstractTextDocumentService {
 									return location;
 								}).collect(Collectors.toList());
 						if (isDefinitionLinkSupport()) {
-							// I don't understand
-							// return Either.forRight(locations);
+							// Uncommented in
+							// https://github.com/eclipse/lsp4mp/issues/215#issuecomment-984714139
+							return Either.forRight(locations);
 						}
 						return Either.forLeft(locations.stream() //
 								.map((link) -> {


### PR DESCRIPTION
Fix for excessive property definition display on hover.
![image](https://user-images.githubusercontent.com/26389510/180008065-97f73ccb-6bc1-4ed0-afe7-d1fcce4b1b5c.png)

Fixes #215 

Fix made as per https://github.com/eclipse/lsp4mp/issues/215#issuecomment-984714139

Signed-off-by: Alexander Chen <alchen@redhat.com>