### PR TITLE
Update Target Platform to 1.16.0-SNAPSHOT version of JDT-LS target.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
@@ -2,7 +2,7 @@
 <?pde version="3.8"?>
 <target name="LSP4MP Target Platform">
 	<locations>
-		<location type="Target" uri="https://repo.eclipse.org/content/repositories/jdtls-releases/org/eclipse/jdt/ls/org.eclipse.jdt.ls.tp/1.14.0.20220721170741/org.eclipse.jdt.ls.tp-1.14.0.20220721170741.target"/>
+		<location type="Target" uri="https://repo.eclipse.org/content/repositories/jdtls-snapshots/org/eclipse/jdt/ls/org.eclipse.jdt.ls.tp/1.16.0-SNAPSHOT/org.eclipse.jdt.ls.tp-1.16.0-20220915.034113-10.target"/>
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>
 				<dependency>

--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -15,7 +15,6 @@
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
-    <jdt.ls.version>1.14.0.20220721170741</jdt.ls.version>
     <tycho.test.platformArgs />
     <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
@@ -37,11 +36,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.14.0/repository/</url>
-    </repository>
-    <repository>
-      <id>jdt.ls.maven</id>
-      <url>https://repo.eclipse.org/content/repositories/jdtls-releases/</url>
+      <url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
     </repository>
   </repositories>
   <build>


### PR DESCRIPTION
- Remove unnecessary reference to JDT-LS version, since repository references automatically get access to all p2 bundles

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>