### PR TITLE
Fix inlay hint + definition when project returns empty properties.

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
@@ -193,9 +193,6 @@ public class PropertiesFileTextDocumentService extends AbstractTextDocumentServi
 		return getPropertiesModelCompose(params.getTextDocument(), (document, cancelChecker) -> {
 			MicroProfileProjectInfoParams projectInfoParams = createProjectInfoParams(params.getTextDocument());
 			MicroProfileProjectInfo projectInfo = getProjectInfoCache().getProjectInfo(projectInfoParams).getNow(null);
-			if (projectInfo == null || projectInfo.getProperties().isEmpty()) {
-				return null;
-			}
 			return getPropertiesFileLanguageService().findDefinition(document, params.getPosition(), projectInfo,
 					microprofileLanguageServer.getLanguageClient(), isDefinitionLinkSupport(), cancelChecker);
 		});
@@ -271,9 +268,6 @@ public class PropertiesFileTextDocumentService extends AbstractTextDocumentServi
 
 	private List<InlayHint> inlayHint(InlayHintParams params, PropertiesModel document,
 			MicroProfileProjectInfo projectInfo, CancelChecker cancelChecker) {
-		if (projectInfo == null || projectInfo.getProperties().isEmpty()) {
-			return null;
-		}
 		return getPropertiesFileLanguageService().getInlayHint(document, projectInfo, params.getRange(), cancelChecker);
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileInlayHint.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileInlayHint.java
@@ -14,6 +14,7 @@
 package org.eclipse.lsp4mp.services.properties;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -23,6 +24,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
+import org.eclipse.lsp4mp.commons.metadata.ItemMetadata;
 import org.eclipse.lsp4mp.commons.utils.ConfigSourcePropertiesProviderUtils;
 import org.eclipse.lsp4mp.commons.utils.IConfigSourcePropertiesProvider;
 import org.eclipse.lsp4mp.commons.utils.PropertyValueExpander;
@@ -63,6 +65,9 @@ class PropertiesFileInlayHint {
 
 	public List<InlayHint> getInlayHint(PropertiesModel document, MicroProfileProjectInfo projectInfo, Range range,
 			CancelChecker cancelChecker) {
+		List<ItemMetadata> metadatas = projectInfo != null && projectInfo.getProperties() != null
+				? projectInfo.getProperties()
+				: Collections.emptyList();
 		List<InlayHint> hints = new ArrayList<>();
 		List<Node> children = document.getChildren();
 		for (Node child : children) {
@@ -73,7 +78,8 @@ class PropertiesFileInlayHint {
 				if (valueNode != null && valueNode.hasExpression()) {
 					// The current property has a value with expression:
 					// ex : server.url=https://${host}:${port:8080}/${endpoint}
-					IConfigSourcePropertiesProvider propertiesProvider = ConfigSourcePropertiesProviderUtils.layer(document, new PropertiesInfoPropertiesProvider(projectInfo.getProperties()));
+					IConfigSourcePropertiesProvider propertiesProvider = ConfigSourcePropertiesProviderUtils
+							.layer(document, new PropertiesInfoPropertiesProvider(metadatas));
 					PropertyValueExpander expander = new PropertyValueExpander(propertiesProvider);
 					String resolved = expander.getValue(property.getKey().getPropertyNameWithProfile());
 					if (resolved != null) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
@@ -730,10 +730,15 @@ public class PropertiesFileAssert {
 
 	public static void testInlayHintFor(String value, MicroProfileInlayHintSettings inlayHintSettings,
 			InlayHint... expected) throws Exception {
+		testInlayHintFor(value, inlayHintSettings, getDefaultMicroProfileProjectInfo(), expected);
+	}
+
+	public static void testInlayHintFor(String value, MicroProfileInlayHintSettings inlayHintSettings,
+			MicroProfileProjectInfo projectInfo, InlayHint... expected) throws Exception {
 		PropertiesModel model = parse(value, null);
 		Range range = null;
 		PropertiesFileLanguageService languageService = new PropertiesFileLanguageService();
-		List<InlayHint> actual = languageService.getInlayHint(model, getDefaultMicroProfileProjectInfo(), range, () -> {
+		List<InlayHint> actual = languageService.getInlayHint(model, projectInfo, range, () -> {
 		});
 		assertInlayHint(actual, expected);
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinitionTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinitionTest.java
@@ -26,8 +26,6 @@ import org.junit.Test;
  */
 public class PropertiesFileDefinitionTest {
 
-	private static final String PROPERTY_DOCUMENT_NAME = "/microprofile.properties";
-
 	@Test
 	public void definitionOnComments() throws BadLocationException, InterruptedException, ExecutionException {
 		String value = "#|";

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionDefinitionTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionDefinitionTest.java
@@ -13,9 +13,12 @@ import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.ll;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.r;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.testDefinitionFor;
 
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.ls.commons.BadLocationException;
+import org.eclipse.lsp4mp.services.properties.PropertiesFileAssert;
 import org.junit.Test;
 
 /**
@@ -71,6 +74,19 @@ public class PropertiesFileExpressionDefinitionTest {
 		String value = "test.property = value\n" + //
 				"other.property = ${test.prop|erty}";
 		testDefinitionFor(value, PROPERTY_DOCUMENT_NAME, ll(PROPERTY_DOCUMENT_NAME, r(1, 19, 32), r(0, 0, 13)));
+
+		// test with project which have none properties
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		projectInfo.setProperties(Collections.emptyList());
+		testDefinitionFor(value, PROPERTY_DOCUMENT_NAME, projectInfo, //
+				PropertiesFileAssert.getDefaultMicroProfilePropertyDefinitionProvider(), //
+				ll(PROPERTY_DOCUMENT_NAME, r(1, 19, 32), r(0, 0, 13)));
+
+		// test with project null
+		testDefinitionFor(value, PROPERTY_DOCUMENT_NAME, null, //
+				PropertiesFileAssert.getDefaultMicroProfilePropertyDefinitionProvider(), //
+				ll(PROPERTY_DOCUMENT_NAME, r(1, 19, 32), r(0, 0, 13)));
+
 	}
 
 	@Test

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionInlayHintTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionInlayHintTest.java
@@ -7,19 +7,22 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.services.properties;
+package org.eclipse.lsp4mp.services.properties.expressions;
 
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.ih;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.p;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.testInlayHintFor;
 
+import java.util.Collections;
+
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.junit.Test;
 
 /**
  * Test inlay hint for the 'microprofile-config.properties' file.
  *
  */
-public class PropertiesFileInlayHintTest {
+public class PropertiesFileExpressionInlayHintTest {
 
 	@Test
 	public void expression() throws Exception {
@@ -28,7 +31,23 @@ public class PropertiesFileInlayHintTest {
 				"app=project\n" + //
 				"service=eclipse/microprofile-config\n" + //
 				"endpoint=${app}/${service}"; // [ project/eclipse/microprofile-config]
+		// test with project which have properties
 		testInlayHintFor(value, //
+				ih(p(0, 51), " https://microprofile.io:8080/project/eclipse/microprofile-config"), //
+				ih(p(4, 26), " project/eclipse/microprofile-config"));
+
+		// test with project which have none properties
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		projectInfo.setProperties(Collections.emptyList());
+		testInlayHintFor(value, //
+				null, //
+				projectInfo, ih(p(0, 51), " https://microprofile.io:8080/project/eclipse/microprofile-config"), //
+				ih(p(4, 26), " project/eclipse/microprofile-config"));
+
+		// test with project null
+		testInlayHintFor(value, //
+				null, //
+				(MicroProfileProjectInfo) null, //
 				ih(p(0, 51), " https://microprofile.io:8080/project/eclipse/microprofile-config"), //
 				ih(p(4, 26), " project/eclipse/microprofile-config"));
 	};
@@ -41,7 +60,9 @@ public class PropertiesFileInlayHintTest {
 				"service=eclipse/microprofile-config\n" + //
 				"endpoint=${app}/${service}";
 		testInlayHintFor(value, //
-				ih(p(0, 46), " https://microprofile.io:${port}/project/eclipse/microprofile-config"), // ${port} is not expanded
+				ih(p(0, 46), " https://microprofile.io:${port}/project/eclipse/microprofile-config"), // ${port} is not
+																										// expanded
 				ih(p(4, 26), " project/eclipse/microprofile-config")); // [project/eclipse/microprofile-config]
 	};
+
 }


### PR DESCRIPTION
Fix inlay hint + definition when project returns empty properties.

Signed-off-by: azerr <azerr@redhat.com>