### PR TITLE
Documentation on hover for properties in properties files

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/plugin.xml
@@ -26,6 +26,7 @@
       <delegateCommandHandler class="org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler">
             <command id="microprofile/projectInfo"/>
             <command id="microprofile/propertyDefinition"/>
+            <command id="microprofile/propertyDocumentation"/>
        </delegateCommandHandler>
    </extension>
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/MicroProfilePropertyDocumentationParams.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/MicroProfilePropertyDocumentationParams.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * MicroProfile property documentation parameters to retrieve the documentation
+ * of the MicroProfile property in Java class field or Java method.
+ */
+public class MicroProfilePropertyDocumentationParams {
+
+	private String uri;
+
+	private String sourceType;
+
+	private String sourceField;
+
+	private String sourceMethod;
+
+	private DocumentFormat documentFormat;
+
+	/**
+	 * Returns the properties file URI.
+	 *
+	 * @return the properties file URI
+	 */
+	public String getUri() {
+		return uri;
+	}
+
+	/**
+	 * Set the properties file URI
+	 *
+	 * @param uri the properties file URI
+	 */
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public String getSourceField() {
+		return sourceField;
+	}
+
+	public void setSourceField(String sourceField) {
+		this.sourceField = sourceField;
+	}
+
+	public String getSourceMethod() {
+		return sourceMethod;
+	}
+
+	public void setSourceMethod(String sourceMethod) {
+		this.sourceMethod = sourceMethod;
+	}
+
+	/**
+	 * Returns the document format for this property documentation request.
+	 *
+	 * @return the document format for this property documentation request
+	 */
+	public DocumentFormat getDocumentFormat() {
+		return documentFormat;
+	}
+
+	/**
+	 * Sets which documentation format the documentation should be returned as.
+	 *
+	 * @param documentFormat the document format that the documentation should be
+	 *                       returned as
+	 */
+	public void setDocumentFormat(DocumentFormat documentFormat) {
+		this.documentFormat = documentFormat;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/GreetingResource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/GreetingResource.java
@@ -24,6 +24,9 @@ public class GreetingResource {
     @ConfigProperty(name = "greeting.missing")
     String missing;
 
+    /**
+     * The <code>number</code> of the greeting.
+     */
     @ConfigProperty(name = "greeting.number", defaultValue="0")
     int number;
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerDocumentationTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerDocumentationTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core;
+
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.fixURI;
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.MicroProfilePropertyDocumentationParams;
+import org.junit.Test;
+
+/**
+ * Tests for {@link PropertiesManager#collectPropertyDocumentation}.
+ */
+public class PropertiesManagerDocumentationTest extends BasePropertiesManagerTest {
+
+	@Test
+	public void testCollectDocumentationMarkdown() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IFile propertiesFile = javaProject.getProject()
+				.getFile(new Path("src/main/resources/META-INF/microprofile-config.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		var params = createDocParams(propertiesFileUri, "org.acme.config.GreetingResource", "number", null,
+				DocumentFormat.Markdown);
+		String documentation = PropertiesManager.getInstance().collectPropertyDocumentation(params, JDT_UTILS, null);
+
+		assertEquals("The `number` of the greeting.", documentation);
+	}
+
+	@Test
+	public void testCollectDocumentationPlainText() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IFile propertiesFile = javaProject.getProject()
+				.getFile(new Path("src/main/resources/META-INF/microprofile-config.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		var params = createDocParams(propertiesFileUri, "org.acme.config.GreetingResource", "number", null,
+				DocumentFormat.PlainText);
+		String documentation = PropertiesManager.getInstance().collectPropertyDocumentation(params, JDT_UTILS, null);
+
+		assertEquals(" The number of the greeting. ", documentation);
+	}
+
+	@Test
+	public void testCollectDocumentationForNoDocs() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IFile propertiesFile = javaProject.getProject()
+				.getFile(new Path("src/main/resources/META-INF/microprofile-config.properties"));
+		String propertiesFileUri = fixURI(propertiesFile.getLocation().toFile().toURI());
+
+		// try markdown
+		var params = createDocParams(propertiesFileUri, "org.acme.config.GreetingResource", "suffix", null,
+				DocumentFormat.Markdown);
+		String documentation = PropertiesManager.getInstance().collectPropertyDocumentation(params, JDT_UTILS, null);
+		assertEquals(null, documentation);
+		// try plaintext
+		params.setDocumentFormat(DocumentFormat.PlainText);
+		documentation = PropertiesManager.getInstance().collectPropertyDocumentation(params, JDT_UTILS, null);
+		assertEquals(null, documentation);
+	}
+
+	public MicroProfilePropertyDocumentationParams createDocParams(String uri, String sourceType, String sourceField,
+			String sourceMethod, DocumentFormat documentFormat) {
+		var params = new MicroProfilePropertyDocumentationParams();
+		params.setUri(uri);
+		params.setSourceType(sourceType);
+		params.setSourceField(sourceField);
+		params.setSourceMethod(sourceMethod);
+		params.setDocumentFormat(documentFormat);
+		return params;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDefinitionTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDefinitionTest.java
@@ -87,8 +87,8 @@ public class MicroProfileConfigJavaDefinitionTest extends BasePropertiesManagerT
 		// Definition override default value
 		// Position(26, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
-		assertJavaDefinitions(p(26, 33), javaFileUri, JDT_UTILS, //
-				def(r(26, 28, 43), propertiesFileUri, "greeting.number"));
+		assertJavaDefinitions(p(29, 33), javaFileUri, JDT_UTILS, //
+				def(r(29, 28, 43), propertiesFileUri, "greeting.number"));
 
 		// Definition when no value
 		// Position(23, 33) is the character after the | symbol:

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaHoverTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaHoverTest.java
@@ -98,9 +98,9 @@ public class MicroProfileConfigJavaHoverTest extends BasePropertiesManagerTest {
 		// Hover override default value
 		// Position(26, 33) is the character after the | symbol:
 		// @ConfigProperty(name = "greet|ing.number", defaultValue="0")
-		assertJavaHover(new Position(26, 33), javaFileUri, JDT_UTILS,
+		assertJavaHover(new Position(29, 33), javaFileUri, JDT_UTILS,
 				h("`greeting.number = 100` *in* [META-INF/microprofile-config.properties](" + propertiesFileUri + ")",
-						26, 28, 43));
+						29, 28, 43));
 
 		// Hover when no value
 		// Position(23, 33) is the character after the | symbol:

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfilePropertyDocumentationParams.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfilePropertyDocumentationParams.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * MicroProfile property documentation parameters to retrieve the documentation
+ * of the MicroProfile property in Java class field or Java method.
+ */
+public class MicroProfilePropertyDocumentationParams {
+
+	private String uri;
+
+	private String sourceType;
+
+	private String sourceField;
+
+	private String sourceMethod;
+
+	private DocumentFormat documentFormat;
+
+	/**
+	 * Returns the properties file URI.
+	 *
+	 * @return the properties file URI
+	 */
+	public String getUri() {
+		return uri;
+	}
+
+	/**
+	 * Set the properties file URI
+	 *
+	 * @param uri the properties file URI
+	 */
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	public String getSourceType() {
+		return sourceType;
+	}
+
+	public void setSourceType(String sourceType) {
+		this.sourceType = sourceType;
+	}
+
+	public String getSourceField() {
+		return sourceField;
+	}
+
+	public void setSourceField(String sourceField) {
+		this.sourceField = sourceField;
+	}
+
+	public String getSourceMethod() {
+		return sourceMethod;
+	}
+
+	public void setSourceMethod(String sourceMethod) {
+		this.sourceMethod = sourceMethod;
+	}
+
+	/**
+	 * Returns the document format for this property documentation request.
+	 *
+	 * @return the document format for this property documentation request
+	 */
+	public DocumentFormat getDocumentFormat() {
+		return documentFormat;
+	}
+
+	/**
+	 * Sets which documentation format the documentation should be returned as.
+	 *
+	 * @param documentFormat the document format that the documentation should be
+	 *                       returned as
+	 */
+	public void setDocumentFormat(DocumentFormat documentFormat) {
+		this.documentFormat = documentFormat;
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileLanguageClientAPI.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileLanguageClientAPI.java
@@ -21,8 +21,9 @@ import org.eclipse.lsp4j.services.LanguageClient;
  * @author Angelo ZERR
  *
  */
-public interface MicroProfileLanguageClientAPI extends LanguageClient, MicroProfileProjectInfoProvider,
-		MicroProfilePropertyDefinitionProvider, MicroProfileJavaCodeActionProvider, MicroProfileJavaCodeLensProvider,
+public interface MicroProfileLanguageClientAPI
+		extends LanguageClient, MicroProfileProjectInfoProvider, MicroProfilePropertyDefinitionProvider,
+		MicroProfilePropertyDocumentationProvider, MicroProfileJavaCodeActionProvider, MicroProfileJavaCodeLensProvider,
 		MicroProfileJavaCompletionProvider, MicroProfileJavaDiagnosticsProvider, MicroProfileJavaDefinitionProvider,
 		MicroProfileJavaHoverProvider, MicroProfileJavaProjectLabelsProvider, MicroProfileJavaFileInfoProvider,
 		MicroProfileJavaCodeActionResolveProvider {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfilePropertyDocumentationProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfilePropertyDocumentationProvider.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.ls.api;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4mp.commons.MicroProfilePropertyDocumentationParams;
+
+/**
+ * MicroProfile property documentation provider.
+ */
+public interface MicroProfilePropertyDocumentationProvider {
+
+	@JsonRequest("microprofile/propertyDocumentation")
+	default CompletableFuture<String> getPropertyDocumentation(MicroProfilePropertyDocumentationParams params) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/properties/PropertiesFileTextDocumentService.java
@@ -146,7 +146,7 @@ public class PropertiesFileTextDocumentService extends AbstractTextDocumentServi
 
 	@Override
 	public CompletableFuture<Hover> hover(HoverParams params) {
-		return getPropertiesModel(params.getTextDocument(), (document, cancelChecker) -> {
+		return getPropertiesModelCompose(params.getTextDocument(), (document, cancelChecker) -> {
 			// Get MicroProfile project information which stores all available MicroProfile
 			// properties
 			// Don't block if it hasn't been computed yet
@@ -160,7 +160,7 @@ public class PropertiesFileTextDocumentService extends AbstractTextDocumentServi
 			// then return hover by using the MicroProfile project information and the
 			// Properties model document
 			return getPropertiesFileLanguageService().doHover(document, params.getPosition(), projectInfo,
-					sharedSettings.getHoverSettings(), cancelChecker);
+					sharedSettings.getHoverSettings(), this.microprofileLanguageServer.getLanguageClient(), cancelChecker);
 		});
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileLanguageService.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileLanguageService.java
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.extensions.ExtendedMicroProfileProjectInfo;
 import org.eclipse.lsp4mp.ls.api.MicroProfilePropertyDefinitionProvider;
+import org.eclipse.lsp4mp.ls.api.MicroProfilePropertyDocumentationProvider;
 import org.eclipse.lsp4mp.model.PropertiesModel;
 import org.eclipse.lsp4mp.settings.MicroProfileCommandCapabilities;
 import org.eclipse.lsp4mp.settings.MicroProfileCompletionCapabilities;
@@ -94,16 +95,19 @@ public class PropertiesFileLanguageService {
 	/**
 	 * Returns Hover object for the currently hovered token
 	 *
-	 * @param document      the properties model document
-	 * @param position      the hover position
-	 * @param projectInfo   the MicroProfile project information
-	 * @param hoverSettings the hover settings
+	 * @param document              the properties model document
+	 * @param position              the hover position
+	 * @param projectInfo           the MicroProfile project information
+	 * @param hoverSettings         the hover settings
+	 * @param documentationProvider the documentation provider
+	 * @param cancelChecker         the cancel checker
 	 * @return Hover object for the currently hovered token
 	 */
-	public Hover doHover(PropertiesModel document, Position position, MicroProfileProjectInfo projectInfo,
-			MicroProfileHoverSettings hoverSettings, CancelChecker cancelChecker) {
+	public CompletableFuture<Hover> doHover(PropertiesModel document, Position position, MicroProfileProjectInfo projectInfo,
+			MicroProfileHoverSettings hoverSettings, MicroProfilePropertyDocumentationProvider documentationProvider,
+			CancelChecker cancelChecker) {
 		updateProperties(projectInfo, document);
-		return hover.doHover(document, position, projectInfo, hoverSettings, cancelChecker);
+		return hover.doHover(document, position, projectInfo, hoverSettings, documentationProvider, cancelChecker);
 	}
 
 	/**

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
@@ -24,14 +24,14 @@ import org.junit.Test;
 public class PropertiesFileHoverTest {
 
 	@Test
-	public void unkwownProperty() throws BadLocationException {
+	public void unkwownProperty() throws Exception {
 		String value = "unkwo|wn";
 		String hoverLabel = null;
 		assertHoverMarkdown(value, hoverLabel, 0);
 	};
 
 	@Test
-	public void testKeyHoverMarkdown() throws BadLocationException {
+	public void testKeyHoverMarkdown() throws Exception {
 		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -44,7 +44,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testKeyHoverPlaintext() throws BadLocationException {
+	public void testKeyHoverPlaintext() throws Exception {
 		String value = "quarkus.applica|tion.name = name";
 		String hoverLabel = "quarkus.application.name" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -57,7 +57,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testKeyHoverNoSpaces() throws BadLocationException {
+	public void testKeyHoverNoSpaces() throws Exception {
 		String value = "quarkus.applica|tion.name=name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -70,27 +70,27 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testNoKeyHoverOnEqualsSign() throws BadLocationException {
+	public void testNoKeyHoverOnEqualsSign() throws Exception {
 		assertHoverMarkdown("quarkus.application.name |= name", null, 0);
 		assertHoverMarkdown("quarkus.application.name|=name", null, 0);
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
 	};
 
 	@Test
-	public void testNoValueHoverOnEqualsSign() throws BadLocationException {
+	public void testNoValueHoverOnEqualsSign() throws Exception {
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow |= DISCARD", null, 0);
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
 	};
 
 	@Test
-	public void testNoHoverOnEqualsWhenNoValue() throws BadLocationException {
+	public void testNoHoverOnEqualsWhenNoValue() throws Exception {
 		String value = "a=1\n" + //
 				"b=|";
 		assertHoverMarkdown(value, null, 0);
 	};
 
 	@Test
-	public void testDefaultProfileHover() throws BadLocationException {
+	public void testDefaultProfileHover() throws Exception {
 		String value = "%d|ev.quarkus.log.syslog.async.overflow=DISCARD";
 		String hoverLabelMarkdown = "**dev**" + System.lineSeparator() + System.lineSeparator()
 				+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator();
@@ -98,7 +98,7 @@ public class PropertiesFileHoverTest {
 	}
 
 	@Test
-	public void testDefaultProfileHoverSpacesInFront() throws BadLocationException {
+	public void testDefaultProfileHoverSpacesInFront() throws Exception {
 		String value = "        %d|ev.quarkus.log.syslog.async.overflow=DISCARD";
 		String hoverLabelMarkdown = "**dev**" + System.lineSeparator() + System.lineSeparator()
 				+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator();
@@ -106,7 +106,7 @@ public class PropertiesFileHoverTest {
 	}
 
 	@Test
-	public void testOnlyDefaultProfile() throws BadLocationException {
+	public void testOnlyDefaultProfile() throws Exception {
 		String value = "%de|v";
 		String hoverLabelMarkdown = "**dev**" + System.lineSeparator() + System.lineSeparator()
 				+ "Profile activated when in development mode (quarkus:dev)." + System.lineSeparator();
@@ -124,7 +124,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testOnlyNonDefaultProfile() throws BadLocationException {
+	public void testOnlyNonDefaultProfile() throws Exception {
 		String value = "%hel|lo";
 		String hoverLabel = null;
 		assertHoverMarkdown(value, hoverLabel, 0);
@@ -137,7 +137,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testKeyWithProfileHoverMarkdown() throws BadLocationException {
+	public void testKeyWithProfileHoverMarkdown() throws Exception {
 		String value = "%dev.quarkus.applica|tion.name = name";
 		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
 				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
@@ -151,7 +151,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testKeyMap() throws BadLocationException {
+	public void testKeyMap() throws Exception {
 		String value = "quar|kus.log.category.\"com.lordofthejars\".level=DEBUG";
 		String hoverLabel = "**quarkus.log.category.\\{\\*\\}.level**" + System.lineSeparator() + System.lineSeparator()
 				+ //
@@ -165,7 +165,7 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void hoverWithEnums() throws BadLocationException {
+	public void hoverWithEnums() throws Exception {
 		String value = "quarkus.log.console.async.overflow=BLO|CK";
 		// OverflowAction enum type
 		String hoverLabel = "**BLOCK**" + System.lineSeparator();
@@ -173,7 +173,7 @@ public class PropertiesFileHoverTest {
 	}
 
 	@Test
-	public void hoverOnValueForLevelBasedOnRule() throws BadLocationException {
+	public void hoverOnValueForLevelBasedOnRule() throws Exception {
 		// quarkus.log.file.level has 'java.util.logging.Level'
 		String value = "quarkus.log.file.level=OF|F ";
 		String hoverLabel = "**OFF**" + //
@@ -186,7 +186,7 @@ public class PropertiesFileHoverTest {
 	}
 
 	@Test
-	public void hoverWithEnumsKebabCase() throws BadLocationException {
+	public void hoverWithEnumsKebabCase() throws Exception {
 		String value = "quarkus.datasource.transaction-isolation-level = read-unc|ommitted";
 		// io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation
 		// enum type

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionHoverTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/expressions/PropertiesFileExpressionHoverTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class PropertiesFileExpressionHoverTest {
 
 	@Test
-	public void hoverWithEnums() throws BadLocationException {
+	public void hoverWithEnums() throws Exception {
 		String value = "quarkus.log.console.async.overflow=${ENV:BLO|CK}";
 		// OverflowAction enum type
 		String hoverLabel = "**BLOCK**" + System.lineSeparator();
@@ -31,7 +31,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverOnValueForLevelBasedOnRule() throws BadLocationException {
+	public void hoverOnValueForLevelBasedOnRule() throws Exception {
 		// quarkus.log.file.level has 'java.util.logging.Level'
 		String value = "quarkus.log.file.level=${ENV:OF|F} ";
 		String hoverLabel = "**OFF**" + //
@@ -44,7 +44,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverWithEnumsKebabCase() throws BadLocationException {
+	public void hoverWithEnumsKebabCase() throws Exception {
 		String value = "quarkus.datasource.transaction-isolation-level = ${ENV:read-unc|ommitted}";
 		// io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation
 		// enum type
@@ -53,13 +53,13 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverInvalidProperty() throws BadLocationException {
+	public void hoverInvalidProperty() throws Exception {
 		String value = "aaa=${b|bb}";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverPropertiesFileReference() throws BadLocationException {
+	public void hoverPropertiesFileReference() throws Exception {
 		String value = "property.one = hello\n" + //
 				"property.two = ${prope|rty.one}";
 		String hoverLabel = "hello";
@@ -67,14 +67,14 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverDefaultPropertyValue() throws BadLocationException {
+	public void hoverDefaultPropertyValue() throws Exception {
 		String value = "property.one = ${mp.openapi.s|can.disable}";
 		String hoverLabel = "false";
 		assertHoverMarkdown(value, hoverLabel, 15);
 	}
 
 	@Test
-	public void hoverResolveTwoSteps() throws BadLocationException {
+	public void hoverResolveTwoSteps() throws Exception {
 		String value = "property.one = hello\n" + //
 				"property.two = ${property.one}\n" + //
 				"property.three = ${property.two}\n" + //
@@ -85,7 +85,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverMixtureOfReferencesAndRawText() throws BadLocationException {
+	public void hoverMixtureOfReferencesAndRawText() throws Exception {
 		String value = "property.one = one\n" + //
 				"property.two = ${property.one} two\n" + //
 				"property.four = ${proper|ty.three} five\n" + //
@@ -95,20 +95,20 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverSelfReference() throws BadLocationException {
+	public void hoverSelfReference() throws Exception {
 		String value = "property.one = ${prop|erty.one}";
 		assertHoverMarkdown(value, "${property.one}", 15);
 	}
 
 	@Test
-	public void hoverCircularReference() throws BadLocationException {
+	public void hoverCircularReference() throws Exception {
 		String value = "property.one = ${property.two}\n" + //
 				"property.two = ${p|roperty.one}";
 		assertHoverMarkdown(value, "${property.two}", 15);
 	}
 
 	@Test
-	public void hoverDependencyTreeAndDefaultValue() throws BadLocationException {
+	public void hoverDependencyTreeAndDefaultValue() throws Exception {
 		String value = "property.one = $|{property.two}\n" + //
 				"property.two=${property.three} ${mp.openapi.scan.disable}\n" + //
 				"property.three = hello";
@@ -116,7 +116,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverAnyCyclePreventsRecursiveResolution() throws BadLocationException {
+	public void hoverAnyCyclePreventsRecursiveResolution() throws Exception {
 		String value = "property.one = ${p|roperty.two}\n" + //
 				"property.two = ${property.three}\n" + //
 				"property.three = hi\n" + //
@@ -126,13 +126,13 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverEmptyPropertyName() throws BadLocationException {
+	public void hoverEmptyPropertyName() throws Exception {
 		String value = "property.one = ${|}";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverBoundsOnPropertyExpression() throws BadLocationException {
+	public void hoverBoundsOnPropertyExpression() throws Exception {
 		String value = "property.one = |${property.two}\n" + //
 				"property.two = hello";
 		assertHoverMarkdown(value, "hello", 15);
@@ -142,7 +142,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverMultilineReferencePropertyExpression() throws BadLocationException {
+	public void hoverMultilineReferencePropertyExpression() throws Exception {
 		String value = "property.one = ${prope|rty.two}\n" + //
 				"property.two = hello \\\n" + //
 				"  there";
@@ -150,7 +150,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyWithReference() throws BadLocationException {
+	public void hoverKeyWithReference() throws Exception {
 		String value = "value = value\n" + //
 				"mp.metri|cs.appName=${value}";
 		assertHoverMarkdown(value, //
@@ -169,7 +169,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyWithNoReferenceButWithDefaultValue() throws BadLocationException {
+	public void hoverKeyWithNoReferenceButWithDefaultValue() throws Exception {
 		String value = "mp.metri|cs.appName=${value:sa}";
 		assertHoverMarkdown(value, //
 				"**mp.metrics.appName**" + //
@@ -187,14 +187,14 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyUndefinedProperty() throws BadLocationException {
+	public void hoverKeyUndefinedProperty() throws Exception {
 		String value = "pr|operty = value";
 		assertHoverMarkdown(value, "**property**" + System.lineSeparator() + System.lineSeparator() + //
 				" * Value: `value`", 0);
 	}
 
 	@Test
-	public void hoverKeyUndefinedPropertyWithReference() throws BadLocationException {
+	public void hoverKeyUndefinedPropertyWithReference() throws Exception {
 		String value = "value = amount\n" + //
 				"pr|operty = ${value}";
 		assertHoverMarkdown(value, "**property**" + System.lineSeparator() + System.lineSeparator() + //
@@ -203,7 +203,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyUndefinedPropertyWithReferenceAndProfile() throws BadLocationException {
+	public void hoverKeyUndefinedPropertyWithReferenceAndProfile() throws Exception {
 		String value = "value = amount\n" + //
 				"%dev.pr|operty = ${value}";
 		assertHoverMarkdown(value, "**property**" + System.lineSeparator() + System.lineSeparator() + //
@@ -213,7 +213,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyWithReferenceAndSelfLoop() throws BadLocationException {
+	public void hoverKeyWithReferenceAndSelfLoop() throws Exception {
 		String value = "value = ${value}\n" + //
 				"mp.metri|cs.appName=${value}";
 		assertHoverMarkdown(value, //
@@ -232,7 +232,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyWithReferenceToEmptyProperty() throws BadLocationException {
+	public void hoverKeyWithReferenceToEmptyProperty() throws Exception {
 		String value = "value =\n" + //
 				"mp.metri|cs.appName = ${value}";
 		assertHoverMarkdown(value, //
@@ -251,7 +251,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverKeyWithReferenceToBlankProperty() throws BadLocationException {
+	public void hoverKeyWithReferenceToBlankProperty() throws Exception {
 		String value = "value =      \n" + //
 				"mp.metri|cs.appName = ${value}";
 		assertHoverMarkdown(value, //
@@ -270,27 +270,27 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverExistingPropertyReferenceWithoutADefaultValue() throws BadLocationException {
+	public void hoverExistingPropertyReferenceWithoutADefaultValue() throws Exception {
 		String value = "my.property = ${quarkus.app|lication.name}";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverExistingPropertyReferenceWithEmptyPropertyValue() throws BadLocationException {
+	public void hoverExistingPropertyReferenceWithEmptyPropertyValue() throws Exception {
 		String value = "quarkus.application.name=\n" + //
 				"my.property = ${quarkus.|application.name}";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverExistingPropertyReferenceWithNullPropertyValue() throws BadLocationException {
+	public void hoverExistingPropertyReferenceWithNullPropertyValue() throws Exception {
 		String value = "my.property = ${quarkus.|application.name}\n" + //
 				"quarkus.application.name=";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression1() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression1() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${foo}}\n" + //
 				"foo = bar\n" + //
@@ -299,7 +299,7 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression2() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression2() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${foo}}\n" + //
 				"foo = bar\n" + //
@@ -308,42 +308,42 @@ public class PropertiesFileExpressionHoverTest {
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression3() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression3() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${asdf}}\n";
 		assertHoverMarkdown(value, "${${asdf}}", 5);
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression4() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression4() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${}\n";
 		assertHoverMarkdown(value, "${}", 5);
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression5() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression5() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${foo}:ASDF}\n";
 		assertHoverMarkdown(value, "ASDF", 5);
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression6() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression6() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${foo}:${foo:}\n";
 		assertNoHover(value);
 	}
 
 	@Test
-	public void hoverWithNestedPropertyExpression7() throws BadLocationException {
+	public void hoverWithNestedPropertyExpression7() throws Exception {
 		String value = "asdf=${hj|kl}\n" + //
 				"hjkl = ${${foo}:${foo:ASDF}\n";
 		assertHoverMarkdown(value, "ASDF", 5);
 	}
 
 	@Test
-	public void hoverWithBillionLaughs() throws BadLocationException {
+	public void hoverWithBillionLaughs() throws Exception {
 		String value = "asdf=${lu|lz}\n" + //
 				"lulz=${lol9}${lol9}${lol9}${lol9}${lol9}${lol9}${lol9}${lol9}${lol9}\n" //
 				+ "lol9=${lol8}${lol8}${lol8}${lol8}${lol8}${lol8}${lol8}${lol8}${lol8}\n" //


### PR DESCRIPTION
Adds a new command `microprofile/propertyDocumentation` to the JDT component to retrieve the documentation for a property. Invokes this command asynchonously when hovering over the property key in a properties file.

Closes #321

Signed-off-by: David Thompson <davthomp@redhat.com>
