### PR TITLE
Update Target Platform to 1.19.0-SNAPSHOT version of JDT-LS target.

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>2.7.2</tycho.version>
+    <tycho.version>3.0.1</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
@@ -24,7 +24,7 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
     <surefire.timeout>600</surefire.timeout>
-    <jdt.ls.version>1.16.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.19.0-SNAPSHOT</jdt.ls.version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>
@@ -36,7 +36,7 @@
     <repository>
       <id>jdt.ls.p2</id>
       <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/milestones/1.15.0/repository/</url>
+      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
     </repository>
     <repository>
       <id>jdt.ls.maven</id>


### PR DESCRIPTION
- Update Tycho 2.7.2 to 3.0.1

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Wouldn't mind having it confirmed in https://github.com/eclipse-tycho/tycho/pull/1217#issuecomment-1341534832 that the new error we're seeing is ok, and not harmful.

Another oddity I encountered : If I don't update Tycho from 2.7.2 -> 3.0.1, then there is a resolution error in tycho-compiler-plugin's validation :ghost: .