### PR TITLE
When finding node at offset, prefer `PropertyKey` over `Assign`

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/Node.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/Node.java
@@ -224,4 +224,5 @@ public abstract class Node {
 	public Node getParent() {
 		return parent;
 	}
+
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/Property.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/model/Property.java
@@ -170,21 +170,32 @@ public class Property extends Node {
 		if (key == null) {
 			return this;
 		}
-		if (key.getEnd() == -1) {
+		/*
+		 * eg.
+		 *
+		 * asdf|
+		 * asdf| = value
+		 * asdf|=value
+		 */
+		if (key.getEnd() == -1 || offset <= key.getEnd()) {
 			return key;
 		}
 		Node assign = getDelimiterAssign();
 		if (assign == null) {
 			return key;
 		}
-		if (assign.getStart() == offset) {
+		Node value = getValue();
+		/*
+		 * eg.
+		 *
+		 * asdf =|
+		 * asdf |= value
+		 * asdf =| value
+		 */
+		if (value == null || offset < value.getStart()) {
 			return assign;
 		}
-		if (offset >= assign.getStart()) {
-			Node value = getValue();
-			return value != null ? value.findNodeAt(offset) : assign;
-		}
-		return key;
+		return value.findNodeAt(offset);
 	}
 
 	@Override

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinition.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinition.java
@@ -77,11 +77,11 @@ public class PropertiesFileDefinition {
 				return getEmptyDefinition();
 			}
 
-			boolean inDefautlValue = false;
+			boolean inDefaultValue = false;
 			if (node.getNodeType() == NodeType.PROPERTY_VALUE_EXPRESSION) {
 				PropertyValueExpression propertyValueExpression = (PropertyValueExpression) node;
-				inDefautlValue = propertyValueExpression.isInDefaultValue(offset);
-				if (!inDefautlValue) {
+				inDefaultValue = propertyValueExpression.isInDefaultValue(offset);
+				if (!inDefaultValue) {
 					return CompletableFuture
 							.completedFuture(findPropertyValueExpressionDefinition(document, propertyValueExpression));
 				}
@@ -101,11 +101,11 @@ public class PropertiesFileDefinition {
 			}
 
 			MicroProfilePropertyDefinitionParams definitionParams = getPropertyDefinitionParams(document, item,
-					projectInfo, node, inDefautlValue);
+					projectInfo, node, inDefaultValue);
 			if (definitionParams == null) {
 				return getEmptyDefinition();
 			}
-			boolean selectDefaultValue = inDefautlValue;
+			boolean selectDefaultValue = inDefaultValue;
 			return provider.getPropertyDefinition(definitionParams).thenApply(target -> {
 				cancelChecker.checkCanceled();
 				if (target == null) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinitionTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDefinitionTest.java
@@ -36,8 +36,40 @@ public class PropertiesFileDefinitionTest {
 	}
 
 	@Test
-	public void definitionOnKey() throws BadLocationException, InterruptedException, ExecutionException {
+	public void definitionOnKeyNoValue() throws BadLocationException, InterruptedException, ExecutionException {
 		String value = "quarkus.application.na|me";
+		testDefinitionFor(value, ll(
+				"jdt://contents/quarkus-core-1.3.2.Final.jar/io.quarkus.runtime/ApplicationConfig.class?=all-quarkus-extensions/C:%5C/Users%5C/azerr%5C/.m2%5C/repository%5C/io%5C/quarkus%5C/quarkus-core%5C/1.3.2.Final%5C/quarkus-core-1.3.2.Final.jar%3Cio.quarkus.runtime(ApplicationConfig.class",
+				r(0, 0, 24), r(16, 28, 32)));
+	}
+
+	@Test
+	public void definitionBeforeKeyNoValue() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "|quarkus.application.name";
+		testDefinitionFor(value, ll(
+				"jdt://contents/quarkus-core-1.3.2.Final.jar/io.quarkus.runtime/ApplicationConfig.class?=all-quarkus-extensions/C:%5C/Users%5C/azerr%5C/.m2%5C/repository%5C/io%5C/quarkus%5C/quarkus-core%5C/1.3.2.Final%5C/quarkus-core-1.3.2.Final.jar%3Cio.quarkus.runtime(ApplicationConfig.class",
+				r(0, 0, 24), r(16, 28, 32)));
+	}
+
+	@Test
+	public void definitionAfterKeyNoValue() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "quarkus.application.name|";
+		testDefinitionFor(value, ll(
+				"jdt://contents/quarkus-core-1.3.2.Final.jar/io.quarkus.runtime/ApplicationConfig.class?=all-quarkus-extensions/C:%5C/Users%5C/azerr%5C/.m2%5C/repository%5C/io%5C/quarkus%5C/quarkus-core%5C/1.3.2.Final%5C/quarkus-core-1.3.2.Final.jar%3Cio.quarkus.runtime(ApplicationConfig.class",
+				r(0, 0, 24), r(16, 28, 32)));
+	}
+
+	@Test
+	public void definitionAfterKeyNoSpace() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "quarkus.application.name|=my-app";
+		testDefinitionFor(value, ll(
+				"jdt://contents/quarkus-core-1.3.2.Final.jar/io.quarkus.runtime/ApplicationConfig.class?=all-quarkus-extensions/C:%5C/Users%5C/azerr%5C/.m2%5C/repository%5C/io%5C/quarkus%5C/quarkus-core%5C/1.3.2.Final%5C/quarkus-core-1.3.2.Final.jar%3Cio.quarkus.runtime(ApplicationConfig.class",
+				r(0, 0, 24), r(16, 28, 32)));
+	}
+
+	@Test
+	public void definitionBeforeKeyNoSpace() throws BadLocationException, InterruptedException, ExecutionException {
+		String value = "|quarkus.application.name=my-app";
 		testDefinitionFor(value, ll(
 				"jdt://contents/quarkus-core-1.3.2.Final.jar/io.quarkus.runtime/ApplicationConfig.class?=all-quarkus-extensions/C:%5C/Users%5C/azerr%5C/.m2%5C/repository%5C/io%5C/quarkus%5C/quarkus-core%5C/1.3.2.Final%5C/quarkus-core-1.3.2.Final.jar%3Cio.quarkus.runtime(ApplicationConfig.class",
 				r(0, 0, 24), r(16, 28, 32)));

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
@@ -12,9 +12,7 @@ package org.eclipse.lsp4mp.services.properties;
 
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.assertHoverMarkdown;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.assertHoverPlaintext;
-import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.assertNoHover;
 
-import org.eclipse.lsp4mp.ls.commons.BadLocationException;
 import org.junit.Test;
 
 /**
@@ -70,16 +68,39 @@ public class PropertiesFileHoverTest {
 	};
 
 	@Test
-	public void testNoKeyHoverOnEqualsSign() throws Exception {
+	public void testKeyHoverOnEqualsSign() throws Exception {
 		assertHoverMarkdown("quarkus.application.name |= name", null, 0);
-		assertHoverMarkdown("quarkus.application.name|=name", null, 0);
-		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
+				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
+				+ System.lineSeparator() + System.lineSeparator() + //
+				" * Type: `java.util.Optional<java.lang.String>`" + System.lineSeparator() + //
+				" * Value: `name`" + System.lineSeparator() + //
+				" * Phase: `buildtime & runtime`" + System.lineSeparator() + //
+				" * Extension: `quarkus-core`";
+		assertHoverMarkdown("quarkus.application.name|=name", hoverLabel, 0);
+		hoverLabel = "**quarkus.log.syslog.async.overflow**" + System.lineSeparator() + System.lineSeparator() + //
+				"Determine whether to block the publisher (rather than drop the message) when the queue is full"
+				+ System.lineSeparator() + System.lineSeparator() + //
+				" * Type: `org.jboss.logmanager.handlers.AsyncHandler.OverflowAction`" + System.lineSeparator() + //
+				" * Default: `block`" + System.lineSeparator() + //
+				" * Value: `DISCARD`" + System.lineSeparator() + //
+				" * Phase: `runtime`" + System.lineSeparator() + //
+				" * Extension: `quarkus-core`";
+		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", hoverLabel, 0);
 	};
 
 	@Test
-	public void testNoValueHoverOnEqualsSign() throws Exception {
+	public void testValueHoverOnEqualsSign() throws Exception {
 		assertHoverMarkdown("quarkus.log.syslog.async.overflow |= DISCARD", null, 0);
-		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", null, 0);
+		String hoverLabel = "**quarkus.log.syslog.async.overflow**" + System.lineSeparator() + System.lineSeparator() + //
+				"Determine whether to block the publisher (rather than drop the message) when the queue is full"
+				+ System.lineSeparator() + System.lineSeparator() + //
+				" * Type: `org.jboss.logmanager.handlers.AsyncHandler.OverflowAction`" + System.lineSeparator() + //
+				" * Default: `block`" + System.lineSeparator() + //
+				" * Value: `DISCARD`" + System.lineSeparator() + //
+				" * Phase: `runtime`" + System.lineSeparator() + //
+				" * Extension: `quarkus-core`";
+		assertHoverMarkdown("quarkus.log.syslog.async.overflow|=DISCARD", hoverLabel, 0);
 	};
 
 	@Test


### PR DESCRIPTION
when finding the node at the `|`:

```property
key|=value
```

return the property key node (`key`) instead of the assign node (`=`).

Note that this doesn't affect the behaviour of this case:

```property
key |= value
```

which will still return the assign node (`=`).

Fixes redhat-developer/quarkus-ls#323

Signed-off-by: David Thompson <davthomp@redhat.com>
