### PR TITLE
Show/hide Java snippets based on cursor location

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/pom.xml
@@ -12,5 +12,4 @@
 	<packaging>eclipse-plugin</packaging>
 	<name>MicroProfile JDT LS Extension</name>
 	<description>MicroProfile JDT LS Extension - Core</description>
-
 </project>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * Represents the context where the cursor is in a Java file.
+ */
+public enum JavaCursorContextKind {
+
+	/**
+	 * The cursor is in a file that does not have a root type declaration.
+	 *
+	 * eg.
+	 * <code><br />
+	 * |<br />
+	 * </code>
+	 */
+	IN_EMPTY_FILE(1),
+
+	/**
+	 * The cursor is before a type declaration body, either at the root of a file or
+	 * within another class. The cursor is before any annotations on the type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * |<br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;private int memberVariable;<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Inject<br />
+	 * &emsp;&emsp;&emsp;&emsp;public static class MyChildClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_CLASS(2),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a method declaration. The cursor is before any annotations on the
+	 * method.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_METHOD(3),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a field declaration. The cursor is before any annotations on the
+	 * field.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_FIELD(4),
+
+	/**
+	 * The cursor is before a type declaration body, either at the root of a file or
+	 * within another class. The cursor is somewhere within the annotation
+	 * declarations on the class.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject|<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;private int memberVariable;<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Inject|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public static class MyChildClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_CLASS_ANNOTATIONS(5),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a method declaration. The cursor is somewhere within the annotation
+	 * declarations on the method.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_METHOD_ANNOTATIONS(6),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a field declaration. The cursor is somewhere within the annotation
+	 * declarations on the field.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_FIELD_ANNOTATIONS(7),
+
+	/**
+	 * The cursor is in a type declaration body, after all the declarations for the
+	 * type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_CLASS(8),
+
+	/**
+	 * None of the above context apply.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	NONE(2000);
+
+	private final int value;
+
+	private JavaCursorContextKind(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextResult.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextResult.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * Represents context related to the cursor location in the given document.
+ */
+public class JavaCursorContextResult {
+
+	private JavaCursorContextKind kind;
+	private String prefix;
+
+	public JavaCursorContextResult(JavaCursorContextKind kind, String prefix) {
+		this.kind = kind;
+		this.prefix = prefix;
+	}
+
+	public JavaCursorContextResult() {
+		this(null, null);
+	}
+
+	/**
+	 * Returns the context of the cursor in the Java file or <code>NONE</code> if
+	 * none of the contexts apply.
+	 *
+	 * For instance, it returns <code>IN_METHOD_ANNOTATIONS</code> if the cursor is
+	 * in the list of annotations before a method declaration.
+	 *
+	 * @return the context of the cursor in the Java file
+	 */
+	public JavaCursorContextKind getKind() {
+		return kind;
+	}
+
+	/**
+	 * Returns the text content to the left of the cursor, up to the first whitespace.
+	 *
+	 * eg.
+	 *
+	 * <code>
+	 * public static|
+	 * </code>
+	 *
+	 * would return <code>"static"</code>
+	 *
+	 * <code>
+	 *      |
+	 * <code>
+	 *
+	 * would return <code>""</code>
+	 *
+	 *@return the text content to the left of the cursor, up to the first whitespace
+	 */
+	public String getPrefix() {
+		return prefix;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileJavaCompletionResult.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileJavaCompletionResult.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+import org.eclipse.lsp4j.CompletionList;
+
+/**
+ * Represents completion information and context calculated by the Java language server component.
+ */
+public class MicroProfileJavaCompletionResult {
+
+	private CompletionList completionList;
+	private JavaCursorContextResult cursorContext;
+
+	public MicroProfileJavaCompletionResult(CompletionList completionList,
+			JavaCursorContextResult cursorContext) {
+		this.completionList = completionList;
+		this.cursorContext = cursorContext;
+	}
+
+	public MicroProfileJavaCompletionResult() {
+		this(null, null);
+	}
+
+	/**
+	 * Returns the list of completion items contributed by the Java language server
+	 * component.
+	 *
+	 * @return the list of completion items contributed by the Java language server
+	 *         component
+	 */
+	public CompletionList getCompletionList() {
+		return completionList;
+	}
+
+	/**
+	 * Returns information on the context of the cursor in the Java file, calculated
+	 * by the Java language server component.
+	 *
+	 * @return information on the context of the cursor in the Java file, calculated
+	 *         by the Java language server component
+	 */
+	public JavaCursorContextResult getCursorContext() {
+		return cursorContext;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -27,6 +28,21 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeMemberDeclaration;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CompletionItem;
@@ -35,8 +51,12 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.JavaCursorContextKind;
+import org.eclipse.lsp4mp.commons.JavaCursorContextResult;
 import org.eclipse.lsp4mp.commons.JavaFileInfo;
+import org.eclipse.lsp4mp.commons.MicroProfileDefinition;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeActionParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
@@ -45,12 +65,12 @@ import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsSettings;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaFileInfoParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaHoverParams;
-import org.eclipse.lsp4mp.commons.MicroProfileDefinition;
 import org.eclipse.lsp4mp.jdt.core.java.codelens.JavaCodeLensContext;
 import org.eclipse.lsp4mp.jdt.core.java.completion.JavaCompletionContext;
 import org.eclipse.lsp4mp.jdt.core.java.definition.JavaDefinitionContext;
 import org.eclipse.lsp4mp.jdt.core.java.diagnostics.JavaDiagnosticsContext;
 import org.eclipse.lsp4mp.jdt.core.java.hover.JavaHoverContext;
+import org.eclipse.lsp4mp.jdt.core.utils.ASTNodeUtils;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
 import org.eclipse.lsp4mp.jdt.internal.core.java.JavaFeaturesRegistry;
 import org.eclipse.lsp4mp.jdt.internal.core.java.codeaction.CodeActionHandler;
@@ -125,8 +145,8 @@ public class PropertiesManagerForJava {
 	 * @return the codeAction list according the given codeAction parameters.
 	 * @throws JavaModelException
 	 */
-	public CodeAction resolveCodeAction(CodeAction unresolved, IJDTUtils utils,
-			IProgressMonitor monitor) throws JavaModelException {
+	public CodeAction resolveCodeAction(CodeAction unresolved, IJDTUtils utils, IProgressMonitor monitor)
+			throws JavaModelException {
 		return codeActionHandler.resolveCodeAction(unresolved, utils, monitor);
 	}
 
@@ -185,8 +205,8 @@ public class PropertiesManagerForJava {
 	 * @return the CompletionItems for the given the completion item params
 	 * @throws JavaModelException
 	 */
-	public CompletionList completion(MicroProfileJavaCompletionParams params, IJDTUtils utils,
-			IProgressMonitor monitor) throws JavaModelException {
+	public CompletionList completion(MicroProfileJavaCompletionParams params, IJDTUtils utils, IProgressMonitor monitor)
+			throws JavaModelException {
 		String uri = params.getUri();
 		ITypeRoot typeRoot = resolveTypeRoot(uri, utils, monitor);
 		if (typeRoot == null) {
@@ -209,9 +229,8 @@ public class PropertiesManagerForJava {
 		}
 
 		completions.forEach(completion -> {
-			List<? extends CompletionItem> collectedCompletionItems = completion.collectCompletionItems(
-					completionContext,
-					monitor);
+			List<? extends CompletionItem> collectedCompletionItems = completion
+					.collectCompletionItems(completionContext, monitor);
 			if (collectedCompletionItems != null) {
 				completionItems.addAll(collectedCompletionItems);
 			}
@@ -307,8 +326,7 @@ public class PropertiesManagerForJava {
 	}
 
 	private void collectDiagnostics(String uri, IJDTUtils utils, DocumentFormat documentFormat,
-			MicroProfileJavaDiagnosticsSettings settings,
-			List<Diagnostic> diagnostics, IProgressMonitor monitor) {
+			MicroProfileJavaDiagnosticsSettings settings, List<Diagnostic> diagnostics, IProgressMonitor monitor) {
 		ITypeRoot typeRoot = resolveTypeRoot(uri, utils, monitor);
 		if (typeRoot == null) {
 			return;
@@ -368,6 +386,133 @@ public class PropertiesManagerForJava {
 		}
 		// TODO : aggregate the hover
 		return hovers.get(0);
+	}
+
+	/**
+	 * Returns the cursor context for the given file and cursor position.
+	 *
+	 * @param params  the completion params that provide the file and cursor
+	 *                position to get the context for
+	 * @param utils   the jdt utils
+	 * @param monitor the progress monitor
+	 * @return the cursor context for the given file and cursor position
+	 * @throws JavaModelException when the buffer for the file cannot be accessed or
+	 *                            the Java model cannot be accessed
+	 */
+	public static JavaCursorContextResult javaCursorContext(MicroProfileJavaCompletionParams params, IJDTUtils utils,
+			IProgressMonitor monitor) throws JavaModelException {
+		String uri = params.getUri();
+		ITypeRoot typeRoot = resolveTypeRoot(uri, utils, monitor);
+
+		if (typeRoot == null) {
+			return new JavaCursorContextResult(JavaCursorContextKind.IN_EMPTY_FILE, "");
+		}
+		CompilationUnit ast = ASTResolving.createQuickFixAST((ICompilationUnit) typeRoot, monitor);
+
+		JavaCursorContextKind kind = getJavaCursorContextKind(params, typeRoot, ast, utils, monitor);
+		String prefix = getJavaCursorPrefix(params, typeRoot, ast, utils, monitor);
+
+		return new JavaCursorContextResult(kind, prefix);
+	}
+
+	private static JavaCursorContextKind getJavaCursorContextKind(MicroProfileJavaCompletionParams params,
+			ITypeRoot typeRoot, CompilationUnit ast, IJDTUtils utils, IProgressMonitor monitor)
+			throws JavaModelException {
+
+		if (typeRoot.findPrimaryType() == null) {
+			return JavaCursorContextKind.IN_EMPTY_FILE;
+		}
+
+		Position completionPosition = params.getPosition();
+		int completionOffset = utils.toOffset(typeRoot.getBuffer(), completionPosition.getLine(),
+				completionPosition.getCharacter());
+
+		NodeFinder nodeFinder = new NodeFinder(ast, completionOffset, 0);
+		ASTNode node = nodeFinder.getCoveringNode();
+		ASTNode oldNode = node;
+		while (node != null && (!(node instanceof AbstractTypeDeclaration)
+				|| offsetOfFirstNonAnnotationModifier((BodyDeclaration) node) >= completionOffset)) {
+			if (node.getParent() != null) {
+				switch (node.getParent().getNodeType()) {
+				case ASTNode.METHOD_DECLARATION:
+				case ASTNode.FIELD_DECLARATION:
+				case ASTNode.ENUM_CONSTANT_DECLARATION:
+				case ASTNode.ANNOTATION_TYPE_MEMBER_DECLARATION:
+					if (!ASTNodeUtils.isAnnotation(node) && node.getStartPosition() < completionOffset) {
+						return JavaCursorContextKind.NONE;
+					}
+					break;
+				}
+			}
+			oldNode = node;
+			node = node.getParent();
+		}
+
+		if (node == null) {
+			// we are likely before or after the type root class declaration
+			FindWhatsBeingAnnotatedASTVisitor visitor = new FindWhatsBeingAnnotatedASTVisitor(completionOffset, false);
+			oldNode.accept(visitor);
+			switch (visitor.getAnnotatedNodeType()) {
+			case ASTNode.TYPE_DECLARATION:
+			case ASTNode.ANNOTATION_TYPE_DECLARATION:
+			case ASTNode.ENUM_DECLARATION:
+			case ASTNode.RECORD_DECLARATION: {
+				if (visitor.isInAnnotations()) {
+					return JavaCursorContextKind.IN_CLASS_ANNOTATIONS;
+				}
+				return JavaCursorContextKind.BEFORE_CLASS;
+			}
+			default:
+				return JavaCursorContextKind.NONE;
+			}
+		}
+
+		AbstractTypeDeclaration typeDeclaration = (AbstractTypeDeclaration) node;
+		FindWhatsBeingAnnotatedASTVisitor visitor = new FindWhatsBeingAnnotatedASTVisitor(completionOffset);
+		typeDeclaration.accept(visitor);
+		switch (visitor.getAnnotatedNodeType()) {
+		case ASTNode.TYPE_DECLARATION:
+		case ASTNode.ANNOTATION_TYPE_DECLARATION:
+		case ASTNode.ENUM_DECLARATION:
+		case ASTNode.RECORD_DECLARATION:
+			return visitor.isInAnnotations() ? JavaCursorContextKind.IN_CLASS_ANNOTATIONS
+					: JavaCursorContextKind.BEFORE_CLASS;
+		case ASTNode.ANNOTATION_TYPE_MEMBER_DECLARATION:
+		case ASTNode.METHOD_DECLARATION:
+			return visitor.isInAnnotations() ? JavaCursorContextKind.IN_METHOD_ANNOTATIONS
+					: JavaCursorContextKind.BEFORE_METHOD;
+		case ASTNode.FIELD_DECLARATION:
+		case ASTNode.ENUM_CONSTANT_DECLARATION:
+			return visitor.isInAnnotations() ? JavaCursorContextKind.IN_FIELD_ANNOTATIONS
+					: JavaCursorContextKind.BEFORE_FIELD;
+		default:
+			return JavaCursorContextKind.IN_CLASS;
+		}
+	}
+
+	private static @NonNull String getJavaCursorPrefix(MicroProfileJavaCompletionParams params, ITypeRoot typeRoot,
+			CompilationUnit ast, IJDTUtils utils, IProgressMonitor monitor) throws JavaModelException {
+		Position completionPosition = params.getPosition();
+		int completionOffset = utils.toOffset(typeRoot.getBuffer(), completionPosition.getLine(),
+				completionPosition.getCharacter());
+
+		String fileContents = null;
+		try {
+			IBuffer buffer = typeRoot.getBuffer();
+			if (buffer == null) {
+				return null;
+			}
+			fileContents = buffer.getContents();
+		} catch (JavaModelException e) {
+			return "";
+		}
+		if (fileContents == null) {
+			return "";
+		}
+		int i;
+		for (i = completionOffset; i > 0 && !Character.isWhitespace(fileContents.charAt(i - 1)); i--) {
+		}
+		return fileContents.substring(i, completionOffset);
 	}
 
 	/**
@@ -442,7 +587,7 @@ public class PropertiesManagerForJava {
 
 	/**
 	 * Given the uri returns a {@link ITypeRoot}. May return null if it can not
-	 * associate the uri with a Java file ot class file.
+	 * associate the uri with a Java file or class file.
 	 *
 	 * @param uri
 	 * @param utils   JDT LS utilities
@@ -464,6 +609,150 @@ public class PropertiesManagerForJava {
 			}
 		}
 		return unit != null ? unit : classFile;
+	}
+
+	/**
+	 * Searches through the AST to figure out the following:
+	 * <ul>
+	 * <li>If an annotation were to be placed at the completionOffset, what type of
+	 * node would it be annotating?</li>
+	 * <li>Is the completionOffset within the list of annotations before a
+	 * member?</li>
+	 * </ul>
+	 */
+	private static class FindWhatsBeingAnnotatedASTVisitor extends ASTVisitor {
+
+		private int completionOffset;
+		private int closest = Integer.MAX_VALUE;
+		private int annotatedNode = 0;
+		private boolean visitedParentType;
+		private boolean inAnnotations = false;
+
+		public FindWhatsBeingAnnotatedASTVisitor(int completionOffset, boolean startingInParent) {
+			this.completionOffset = completionOffset;
+			this.visitedParentType = !startingInParent;
+		}
+
+		public FindWhatsBeingAnnotatedASTVisitor(int completionOffset) {
+			this(completionOffset, true);
+		}
+
+		@Override
+		public boolean visit(MethodDeclaration node) {
+			return visitNode(node);
+		}
+
+		@Override
+		public boolean visit(FieldDeclaration node) {
+			return visitNode(node);
+		}
+
+		@Override
+		public boolean visit(EnumConstantDeclaration node) {
+			return visitNode(node);
+		}
+
+		@Override
+		public boolean visit(AnnotationTypeMemberDeclaration node) {
+			return visitNode(node);
+		}
+
+		@Override
+		public boolean visit(TypeDeclaration node) {
+			return visitAbstractType(node);
+		}
+
+		@Override
+		public boolean visit(EnumDeclaration node) {
+			return visitAbstractType(node);
+		}
+
+		@Override
+		public boolean visit(AnnotationTypeDeclaration node) {
+			return visitAbstractType(node);
+		}
+
+		@Override
+		public boolean visit(RecordDeclaration node) {
+			return visitAbstractType(node);
+		}
+
+		private boolean visitAbstractType(AbstractTypeDeclaration node) {
+			// we need to visit the children of the first type declaration,
+			// since the visitor start visiting from the supplied node.
+			if (!visitedParentType) {
+				visitedParentType = true;
+				return true;
+			}
+			return visitNode(node);
+		}
+
+		private boolean visitNode(BodyDeclaration node) {
+			// consider the start of the declaration to be after the annotations
+			int start = node.modifiers().isEmpty() ? node.getStartPosition() : offsetOfFirstNonAnnotationModifier(node);
+			if (start < closest && completionOffset <= start) {
+				closest = node.getStartPosition();
+				annotatedNode = node.getNodeType();
+				inAnnotations = node.getStartPosition() < completionOffset && completionOffset <= start;
+			}
+			// We don't want to enter nested classes
+			return false;
+		}
+
+		/**
+		 * Returns the type of the node that an annotation placed at the completion
+		 * offset would be annotating.
+		 *
+		 * @see org.eclipse.jdt.core.dom.ASTNode#getNodeType()
+		 * @return the type of the node that an annotation placed at the completion
+		 *         offset would be annotating
+		 */
+		public int getAnnotatedNodeType() {
+			return annotatedNode;
+		}
+
+		/**
+		 * Returns true if the completion offset is within the list of annotations
+		 * preceding a body declaration (field, method, class declaration) or false
+		 * otherwise.
+		 *
+		 * @return true if the completion offset is within the list of annotations
+		 *         preceding a body declaration (field, method, class declaration) or
+		 *         false otherwise
+		 */
+		public boolean isInAnnotations() {
+			return inAnnotations;
+		}
+
+	}
+
+	private static int offsetOfFirstNonAnnotationModifier(BodyDeclaration node) {
+		List modifiers = node.modifiers();
+		for (int i = 0; i < modifiers.size(); i++) {
+			ASTNode modifier = (ASTNode) modifiers.get(i);
+			if (!ASTNodeUtils.isAnnotation(modifier)) {
+				return modifier.getStartPosition();
+			}
+		}
+		if (node instanceof MethodDeclaration method) {
+			return method.getReturnType2().getStartPosition();
+		} else if (node instanceof FieldDeclaration field) {
+			return field.getType().getStartPosition();
+		} else {
+			var type = (AbstractTypeDeclaration) node;
+			int nameOffset = type.getName().getStartPosition();
+			int keywordLength = (switch (type.getNodeType()) {
+			case ASTNode.TYPE_DECLARATION -> ((TypeDeclaration) type).isInterface() ? "interface" : "class";
+			case ASTNode.ENUM_DECLARATION -> "enum";
+			case ASTNode.ANNOTATION_TYPE_DECLARATION -> "@interface";
+			case ASTNode.RECORD_DECLARATION -> "record";
+			default -> "";
+			}).length();
+
+			// HACK: this assumes the code contains one space between the keyword and the
+			// type name, which isn't always the case
+			return nameOffset - (keywordLength + 1);
+		}
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/ASTNodeUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/ASTNodeUtils.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.utils;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+
+/**
+ * Utility methods for working with {@link ASTNode}.
+ */
+public class ASTNodeUtils {
+
+	private ASTNodeUtils() {
+	}
+
+	/**
+	 * Returns true if the given <code>ASTNode</code> represents an annotation, and false otherwise.
+	 *
+	 * @param node the ast node to check, assumed to be non-null
+	 * @return true if the given <code>ASTNode</code> represents an annotation, and false otherwise
+	 */
+	public static boolean isAnnotation(ASTNode node) {
+		int nodeType = node.getNodeType();
+		return nodeType == ASTNode.MARKER_ANNOTATION || nodeType == ASTNode.SINGLE_MEMBER_ANNOTATION
+				|| nodeType == ASTNode.NORMAL_ANNOTATION;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/MicroProfileDelegateCommandHandlerForJava.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/MicroProfileDelegateCommandHandlerForJava.java
@@ -39,11 +39,14 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4mp.commons.CodeActionResolveData;
 import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.JavaCursorContextKind;
+import org.eclipse.lsp4mp.commons.JavaCursorContextResult;
 import org.eclipse.lsp4mp.commons.JavaFileInfo;
 import org.eclipse.lsp4mp.commons.MicroProfileDefinition;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeActionParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionResult;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDefinitionParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsSettings;
@@ -271,19 +274,21 @@ public class MicroProfileDelegateCommandHandlerForJava extends AbstractMicroProf
 	}
 
 	/**
-	 * Return the completion items for the given arguments
+	 * Return the completion result for the given arguments
 	 *
 	 * @param arguments
 	 * @param commandId
 	 * @param monitor
-	 * @return the completion items for the given arguments
+	 * @return the completion result for the given arguments
 	 * @throws JavaModelException
 	 * @throws CoreException
 	 */
-	private static CompletionList getCompletionForJava(List<Object> arguments, String commandId,
+	private static MicroProfileJavaCompletionResult getCompletionForJava(List<Object> arguments, String commandId,
 			IProgressMonitor monitor) throws JavaModelException, CoreException {
 		MicroProfileJavaCompletionParams params = createMicroProfileJavaCompletionParams(arguments, commandId);
-		return PropertiesManagerForJava.getInstance().completion(params, JDTUtilsLSImpl.getInstance(), monitor);
+		CompletionList completionList = PropertiesManagerForJava.getInstance().completion(params, JDTUtilsLSImpl.getInstance(), monitor);
+		JavaCursorContextResult cursorContext = PropertiesManagerForJava.javaCursorContext(params, JDTUtilsLSImpl.getInstance(), monitor);
+		return new MicroProfileJavaCompletionResult(completionList, cursorContext);
 	}
 
 	/**
@@ -376,7 +381,6 @@ public class MicroProfileDelegateCommandHandlerForJava extends AbstractMicroProf
 		MicroProfileJavaDiagnosticsParams params = createMicroProfileJavaDiagnosticsParams(arguments, commandId);
 		// Return diagnostics from parameter
 		return PropertiesManagerForJava.getInstance().diagnostics(params, JDTUtilsLSImpl.getInstance(), monitor);
-
 	}
 
 	/**
@@ -459,4 +463,5 @@ public class MicroProfileDelegateCommandHandlerForJava extends AbstractMicroProf
 		boolean surroundEqualsWithSpaces = ((Boolean) obj.get("surroundEqualsWithSpaces")).booleanValue();
 		return new MicroProfileJavaHoverParams(javaFileUri, hoverPosition, documentFormat, surroundEqualsWithSpaces);
 	}
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyAnnotation.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyAnnotation.java
@@ -1,0 +1,9 @@
+package org.acme.config;
+
+public @interface MyAnnotation {
+
+    public static String MY_STRING = "asdf";
+
+    public String value() default MY_STRING;
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyEnum.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyEnum.java
@@ -1,0 +1,11 @@
+package org.acme.config;
+
+public enum MyEnum {
+
+    VALUE;
+
+    public static String MY_STRING = "asdf";
+
+    public void helloWorld();
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyInterface.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyInterface.java
@@ -1,0 +1,9 @@
+package org.acme.config;
+
+public interface MyInterface {
+
+    public static String MY_STRING = "asdf";
+
+    public void helloWorld();
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyNestedClass.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-hover/src/main/java/org/acme/config/MyNestedClass.java
@@ -1,0 +1,10 @@
+package org.acme.config;
+
+@Singleton
+public class MyNestedClass {
+
+    @Singleton
+    static class MyNestedNestedClass {
+
+    }
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
@@ -1,0 +1,426 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.snippets;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4mp.commons.JavaCursorContextKind;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for the implementation of
+ * <code>microprofile/java/javaCursorContext</code>.
+ */
+public class JavaFileCursorContextTest extends BasePropertiesManagerTest {
+
+	private static final IProgressMonitor MONITOR = new NullProgressMonitor();
+
+	@After
+	public void cleanUp() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		javaFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		javaFile.setContents(new ByteArrayInputStream("".getBytes()), 0, MONITOR);
+	}
+
+	// context kind tests
+
+	@Test
+	public void testEmptyFileContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// |
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 0));
+		assertEquals(JavaCursorContextKind.IN_EMPTY_FILE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testJustSnippetFileContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+		javaFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		javaFile.setContents(new ByteArrayInputStream("rest_class".getBytes()), 0, MONITOR);
+
+		// rest_class|
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(0, "rest_class".length()));
+		assertEquals(JavaCursorContextKind.IN_EMPTY_FILE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// |rest_class
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 0));
+		assertEquals(JavaCursorContextKind.IN_EMPTY_FILE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// rest|_class
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 4));
+		assertEquals(JavaCursorContextKind.IN_EMPTY_FILE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testBeforeFieldContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// @ConfigProperty(name = "greeting.message")
+		// |String message;
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(15, 4));
+		assertEquals(JavaCursorContextKind.IN_FIELD_ANNOTATIONS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// |@ConfigProperty(name = "greeting.message")
+		// String message;
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(14, 4));
+		assertEquals(JavaCursorContextKind.BEFORE_FIELD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testBeforeMethodContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// @GET
+		// @Produces(MediaType.TEXT_PLAIN)
+		// |public String hello() {
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(34, 4));
+		assertEquals(JavaCursorContextKind.IN_METHOD_ANNOTATIONS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// |@GET
+		// @Produces(MediaType.TEXT_PLAIN)
+		// public String hello() {
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(32, 4));
+		assertEquals(JavaCursorContextKind.BEFORE_METHOD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testInMethodContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// @GET
+		// @Produces(MediaType.TEXT_PLAIN)
+		// public String hello() {
+		// | return message + " " + name.orElse("world") + suffix;
+		// }
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(35, 0));
+		assertEquals(JavaCursorContextKind.NONE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// @GET
+		// @Produces(MediaType.TEXT_PLAIN)
+		// p|ublic String hello() {
+		// return message + " " + name.orElse("world") + suffix;
+		// }
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(34, 5));
+		assertEquals(JavaCursorContextKind.NONE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testInClassContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// public String hello() {
+		// return message + " " + name.orElse("world") + suffix;
+		// }
+		// |}
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(37, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testAfterClassContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/GreetingResource.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// public String hello() {
+		// return message + " " + name.orElse("world") + suffix;
+		// }
+		// }
+		// |
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(38, 0));
+		assertEquals(JavaCursorContextKind.NONE,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testClassContextUsingInterface() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/MyInterface.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// public interface MyInterface {
+		// |
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(3, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_FIELD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// public interface MyInterface {
+		// ...
+		// public void helloWorld();
+		// |
+		// }
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(7, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testClassContextUsingEnum() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/MyEnum.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// public enum MyEnum {
+		// |
+		// VALUE;
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(3, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_FIELD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// public enum MyEnum {
+		// ...
+		// |
+		// public void helloWorld();
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(7, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_METHOD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// public enum MyEnum {
+		// ...
+		// public void helloWorld();
+		// |
+		// }
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(9, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testClassContextUsingAnnotation() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/MyAnnotation.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// public @interface MyAnnotation {
+		// |
+		// public static String MY_STRING = "asdf";
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(3, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_FIELD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// public @interface MyAnnotation {
+		// ...
+		// |
+		// public String value() default MY_STRING;
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(5, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_METHOD,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// public @interface MyAnnotation {
+		// ...
+		// public String value() default MY_STRING;
+		// |
+		// }
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(7, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	@Test
+	public void testBeforeClassContext() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/MyNestedClass.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// ...
+		// @Singleton
+		// public class MyNestedClass {
+		// |
+		// @Singleton
+		// static class MyNestedNestedClass {
+		// ...
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(4, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// @Singleton
+		// public class MyNestedClass {
+		//
+		// |@Singleton
+		// static class MyNestedNestedClass {
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(5, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// @Singleton
+		// public class MyNestedClass {
+		//
+		// @Singleton
+		// | static class MyNestedNestedClass {
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(6, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS_ANNOTATIONS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// |
+		// @Singleton
+		// public class MyNestedClass {
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(1, 0));
+		assertEquals(JavaCursorContextKind.BEFORE_CLASS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+
+		// ...
+		// @Singleton
+		// |public class MyNestedClass {
+		// ...
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(3, 0));
+		assertEquals(JavaCursorContextKind.IN_CLASS_ANNOTATIONS,
+				PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getKind());
+	}
+
+	// prefix tests
+
+	@Test
+	public void testAtBeginningOfFile() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+
+		// |
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 0));
+		assertEquals("", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+	}
+
+	@Test
+	public void testOneWord() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+		javaFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		javaFile.setContents(new ByteArrayInputStream("rest_class".getBytes()), 0, MONITOR);
+
+		// rest_class|
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri,
+				new Position(0, "rest_class".length()));
+		assertEquals("rest_class", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+
+		// |rest_class
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 0));
+		assertEquals("", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+
+		// rest_|class
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 5));
+		assertEquals("rest_", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+	}
+
+	@Test
+	public void testTwoWords() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
+		IProject project = javaProject.getProject();
+		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
+		String javaFileUri = javaFile.getLocation().toFile().toURI().toString();
+		javaFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		javaFile.setContents(new ByteArrayInputStream("asdf hjkl".getBytes()), 0, MONITOR);
+
+		// asdf hjk|l
+		MicroProfileJavaCompletionParams params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 8));
+		assertEquals("hjk", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+
+		// asdf |hjkl
+		params = new MicroProfileJavaCompletionParams(javaFileUri, new Position(0, 5));
+		assertEquals("", PropertiesManagerForJava.javaCursorContext(params, JDT_UTILS, MONITOR).getPrefix());
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextKind.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * Represents the context where the cursor is in a Java file.
+ */
+public enum JavaCursorContextKind {
+
+	/**
+	 * The cursor is in a file that does not have a root type declaration.
+	 *
+	 * eg.
+	 * <code><br />
+	 * |<br />
+	 * </code>
+	 */
+	IN_EMPTY_FILE(1),
+
+	/**
+	 * The cursor is before a type declaration body, either at the root of a file or
+	 * within another class. The cursor is before any annotations on the type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * |<br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;private int memberVariable;<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Inject<br />
+	 * &emsp;&emsp;&emsp;&emsp;public static class MyChildClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_CLASS(2),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a method declaration. The cursor is before any annotations on the
+	 * method.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_METHOD(3),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a field declaration. The cursor is before any annotations on the
+	 * field.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * }<br />
+	 * </code>
+	 */
+	BEFORE_FIELD(4),
+
+	/**
+	 * The cursor is before a type declaration body, either at the root of a file or
+	 * within another class. The cursor is somewhere within the annotation
+	 * declarations on the class.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject|<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * }<br />
+	 * </code>
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * &commat;Inject<br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;private int memberVariable;<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Inject|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public static class MyChildClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_CLASS_ANNOTATIONS(5),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a method declaration. The cursor is somewhere within the annotation
+	 * declarations on the method.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_METHOD_ANNOTATIONS(6),
+
+	/**
+	 * The cursor is in a type declaration body, and the next declaration in the
+	 * body is a field declaration. The cursor is somewhere within the annotation
+	 * declarations on the field.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated|<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_FIELD_ANNOTATIONS(7),
+
+	/**
+	 * The cursor is in a type declaration body, after all the declarations for the
+	 * type.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public String myString;<br />
+	 * &emsp;&emsp;&emsp;&emsp;|<br />
+	 * }<br />
+	 * </code>
+	 */
+	IN_CLASS(8),
+
+	/**
+	 * None of the above context apply.
+	 *
+	 * eg.
+	 * <code>
+	 * <br />
+	 * package org.acme;<br />
+	 * <br />
+	 * public class MyClass {<br />
+	 * <br />
+	 * &emsp;&emsp;&emsp;&emsp;&commat;Deprecated<br />
+	 * &emsp;&emsp;&emsp;&emsp;public void myMethod() {<br />
+	 * &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;|<br />
+	 * &emsp;&emsp;&emsp;&emsp;}<br />
+	 * }<br />
+	 * </code>
+	 */
+	NONE(2000);
+
+	private final int value;
+
+	private JavaCursorContextKind(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public static JavaCursorContextKind forValue(int value) {
+		JavaCursorContextKind[] allValues = JavaCursorContextKind.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextResult.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/JavaCursorContextResult.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+/**
+ * Represents context related to the cursor location in the given document.
+ */
+public class JavaCursorContextResult {
+
+	private JavaCursorContextKind kind;
+	private String prefix;
+
+	public JavaCursorContextResult(JavaCursorContextKind kind, String prefix) {
+		this.kind = kind;
+		this.prefix = prefix;
+	}
+
+	public JavaCursorContextResult() {
+		this(null, null);
+	}
+
+	/**
+	 * Returns the context of the cursor in the Java file or <code>NONE</code> if
+	 * none of the contexts apply.
+	 *
+	 * For instance, it returns <code>IN_METHOD_ANNOTATIONS</code> if the cursor is
+	 * in the list of annotations before a method declaration.
+	 *
+	 * @return the context of the cursor in the Java file
+	 */
+	public JavaCursorContextKind getKind() {
+		return kind;
+	}
+
+	/**
+	 * Returns the text content to the left of the cursor, up to the first whitespace.
+	 *
+	 * eg.
+	 *
+	 * <code>
+	 * public static|
+	 * </code>
+	 *
+	 * would return <code>"static"</code>
+	 *
+	 * <code>
+	 *      |
+	 * <code>
+	 *
+	 * would return <code>""</code>
+	 *
+	 *@return the text content to the left of the cursor, up to the first whitespace
+	 */
+	public String getPrefix() {
+		return prefix;
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileJavaCompletionResult.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileJavaCompletionResult.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.commons;
+
+import org.eclipse.lsp4j.CompletionList;
+
+/**
+ * Represents completion information and context calculated by the Java language server component.
+ */
+public class MicroProfileJavaCompletionResult {
+
+	private CompletionList completionList;
+	private JavaCursorContextResult cursorContext;
+
+	public MicroProfileJavaCompletionResult(CompletionList completionList,
+			JavaCursorContextResult cursorContext) {
+		this.completionList = completionList;
+		this.cursorContext = cursorContext;
+	}
+
+	public MicroProfileJavaCompletionResult() {
+		this(null, null);
+	}
+
+	/**
+	 * Returns the list of completion items contributed by the Java language server
+	 * component.
+	 *
+	 * @return the list of completion items contributed by the Java language server
+	 *         component
+	 */
+	public CompletionList getCompletionList() {
+		return completionList;
+	}
+
+	/**
+	 * Returns information on the context of the cursor in the Java file, calculated
+	 * by the Java language server component.
+	 *
+	 * @return information on the context of the cursor in the Java file, calculated
+	 *         by the Java language server component
+	 */
+	public JavaCursorContextResult getCursorContext() {
+		return cursorContext;
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileJavaCursorContextProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileJavaCursorContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2021 Red Hat Inc. and others.
+* Copyright (c) 2023 Red Hat Inc. and others.
 *
 * This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,18 +16,19 @@ package org.eclipse.lsp4mp.ls.api;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4mp.commons.JavaCursorContextResult;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
-import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionResult;
 
 /**
- * Interface for MicroProfile specific completion in Java files
+ * Returns context related to the cursor location in the given document,
+ * or null if the client doesn't yet support this.
  *
- * @author datho7561
+ * @see JavaCursorContextResult
  */
-public interface MicroProfileJavaCompletionProvider {
+public interface MicroProfileJavaCursorContextProvider {
 
-	@JsonRequest("microprofile/java/completion")
-	default CompletableFuture<MicroProfileJavaCompletionResult> getJavaCompletion(MicroProfileJavaCompletionParams javaParams) {
+	@JsonRequest("microprofile/java/javaCursorContext")
+	default CompletableFuture<JavaCursorContextResult> getJavaCursorContext(MicroProfileJavaCompletionParams context) {
 		return CompletableFuture.completedFuture(null);
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileLanguageClientAPI.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/api/MicroProfileLanguageClientAPI.java
@@ -26,6 +26,6 @@ public interface MicroProfileLanguageClientAPI
 		MicroProfilePropertyDocumentationProvider, MicroProfileJavaCodeActionProvider, MicroProfileJavaCodeLensProvider,
 		MicroProfileJavaCompletionProvider, MicroProfileJavaDiagnosticsProvider, MicroProfileJavaDefinitionProvider,
 		MicroProfileJavaHoverProvider, MicroProfileJavaProjectLabelsProvider, MicroProfileJavaFileInfoProvider,
-		MicroProfileJavaCodeActionResolveProvider {
+		MicroProfileJavaCodeActionResolveProvider, MicroProfileJavaCursorContextProvider {
 
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/JavaSnippetCompletionContext.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/JavaSnippetCompletionContext.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.snippets;
+
+import org.eclipse.lsp4mp.commons.JavaCursorContextResult;
+import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
+
+/**
+ * Represents the context from the Java file needed in order to determine what
+ * snippets should be suggested.
+ */
+public class JavaSnippetCompletionContext {
+
+	private ProjectLabelInfoEntry projectLabelInfoEntry;
+	private JavaCursorContextResult javaCursorContextResult;
+
+	public JavaSnippetCompletionContext(ProjectLabelInfoEntry projectLabelInfoEntry,
+			JavaCursorContextResult javaCursorContextResult) {
+		this.projectLabelInfoEntry = projectLabelInfoEntry;
+		this.javaCursorContextResult = javaCursorContextResult;
+	}
+
+	/**
+	 * Returns the project label info entry for the file in which completion was
+	 * triggered.
+	 *
+	 * @return the project label info entry for the file in which completion was
+	 *         triggered
+	 */
+	public ProjectLabelInfoEntry getProjectLabelInfoEntry() {
+		return projectLabelInfoEntry;
+	}
+
+	/**
+	 * Returns the context related to the cursor location in the given document.
+	 *
+	 * @return the context related to the cursor location in the given document
+	 */
+	public JavaCursorContextResult getJavaCursorContextResult() {
+		return javaCursorContextResult;
+	}
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/SnippetContentType.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/snippets/SnippetContentType.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.snippets;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents the type of the content of a snippet.
+ */
+public enum SnippetContentType {
+
+	@SerializedName("class")
+	CLASS, //
+
+	@SerializedName("method")
+	METHOD, //
+
+	@SerializedName("field")
+	FIELD, //
+
+	@SerializedName("method-annotation")
+	METHOD_ANNOTATION;
+
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/jakarta-rest.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/jakarta-rest.json
@@ -24,7 +24,8 @@
       "type": [
         "javax.ws.rs.GET",
         "jakarta.ws.rs.GET"
-      ]
+      ],
+      "contentType": "class"
     }
   },
   "New REST resource GET method": {
@@ -41,7 +42,8 @@
       "type": [
         "javax.ws.rs.GET",
         "jakarta.ws.rs.GET"
-      ]
+      ],
+      "contentType": "method"
     }
   }
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-faulttolerance.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-faulttolerance.json
@@ -8,7 +8,8 @@
     ],
     "description": "The annotation to define a method execution timeout.",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.Timeout"
+      "type": "org.eclipse.microprofile.faulttolerance.Timeout",
+      "contentType": "method-annotation"
     }
   },
   "@Retry": {
@@ -25,7 +26,8 @@
     ],
     "description": "The retry annotation to define the number of retries",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.Retry"
+      "type": "org.eclipse.microprofile.faulttolerance.Retry",
+      "contentType": "method-annotation"
     }
   },
   "@Fallback with method": {
@@ -41,7 +43,8 @@
     ],
     "description": "The fallback annotation using a fallback method",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.Fallback"
+      "type": "org.eclipse.microprofile.faulttolerance.Fallback",
+      "contentType": "method-annotation"
     }
   },
   "@Fallback with class": {
@@ -57,7 +60,8 @@
     ],
     "description": "The fallback annotation using a fallback class",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.Fallback"
+      "type": "org.eclipse.microprofile.faulttolerance.Fallback",
+      "contentType": "method-annotation"
     }
   },
   "@CircuitBreaker": {
@@ -75,7 +79,8 @@
     ],
     "description": "Defines a circuit breaker policy to an individual method or a class.",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.CircuitBreaker"
+      "type": "org.eclipse.microprofile.faulttolerance.CircuitBreaker",
+      "contentType": "method-annotation"
     }
   },
   "@Bulkhead": {
@@ -87,7 +92,8 @@
     ],
     "description": "Define bulkhead policy to limit the number of the concurrent calls to an instance.",
     "context": {
-      "type": "org.eclipse.microprofile.faulttolerance.Bulkhead"
+      "type": "org.eclipse.microprofile.faulttolerance.Bulkhead",
+      "contentType": "method-annotation"
     }
   }
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-health.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-health.json
@@ -21,7 +21,8 @@
       "}"
     ],
     "context": {
-      "type": "org.eclipse.microprofile.health.Readiness"
+      "type": "org.eclipse.microprofile.health.Readiness",
+      "contentType": "class"
     },
     "description": "MicroProfile Health readiness check"
   },
@@ -47,7 +48,8 @@
       "}"
     ],
     "context": {
-      "type": "org.eclipse.microprofile.health.Liveness"
+      "type": "org.eclipse.microprofile.health.Liveness",
+      "contentType": "class"
     },
     "description": "MicroProfile Health liveness check"
   }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-metrics.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-metrics.json
@@ -12,7 +12,8 @@
     ],
     "description": "An annotation that contains the metadata information when requesting a metric to be injected or produced. This annotation can be used on fields of type Meter, Timer, Counter, and Histogram. For Gauge, the @Metric annotation can only be used on producer methods/fields.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.Metric"
+      "type": "org.eclipse.microprofile.metrics.annotation.Metric",
+      "contentType": "method-annotation"
     }
   },
   "@Counted": {
@@ -27,7 +28,8 @@
     ],
     "description": "Denotes a counter, which counts the invocations of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.Counted"
+      "type": "org.eclipse.microprofile.metrics.annotation.Counted",
+      "contentType": "method-annotation"
     }
   },
   "@Gauge": {
@@ -43,7 +45,8 @@
     ],
     "description": "Denotes a gauge, which samples the value of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.Gauge"
+      "type": "org.eclipse.microprofile.metrics.annotation.Gauge",
+      "contentType": "method-annotation"
     }
   },
   "@ConcurrentGauge": {
@@ -58,7 +61,8 @@
     ],
     "description": "Denotes a gauge which counts the parallel invocations of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.ConcurrentGauge"
+      "type": "org.eclipse.microprofile.metrics.annotation.ConcurrentGauge",
+      "contentType": "method-annotation"
     }
   },
   "@Metered": {
@@ -73,7 +77,8 @@
     ],
     "description": "Denotes a meter, which tracks the frequency of invocations of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.Metered"
+      "type": "org.eclipse.microprofile.metrics.annotation.Metered",
+      "contentType": "method-annotation"
     }
   },
   "@Timed": {
@@ -88,7 +93,8 @@
     ],
     "description": "Denotes a timer, which tracks duration of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.Timed"
+      "type": "org.eclipse.microprofile.metrics.annotation.Timed",
+      "contentType": "method-annotation"
     }
   },
   "@SimplyTimed": {
@@ -103,7 +109,8 @@
     ],
     "description": "Denotes a simple timer, which tracks duration and invocations of the annotated object.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.SimplyTimed"
+      "type": "org.eclipse.microprofile.metrics.annotation.SimplyTimed",
+      "contentType": "method-annotation"
     }
   },
   "@RegistryType": {
@@ -115,7 +122,8 @@
     ],
     "description": "Qualifies the scope of Metric Registry to inject when injecting a MetricRegistry.",
     "context": {
-      "type": "org.eclipse.microprofile.metrics.annotation.RegistryType"
+      "type": "org.eclipse.microprofile.metrics.annotation.RegistryType",
+      "contentType": "method-annotation"
     }
   }
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-openapi.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-openapi.json
@@ -12,7 +12,8 @@
     ],
     "description": "Describes an operation or typically a HTTP method against a specific path.",
     "context": {
-    	"type": "org.eclipse.microprofile.openapi.annotations.Operation"
+      "type": "org.eclipse.microprofile.openapi.annotations.Operation",
+      "contentType": "method-annotation"
     }
   },
   "@Content": {
@@ -24,7 +25,8 @@
     ],
     "description": "Provides media type",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.media.Content"
+      "type": "org.eclipse.microprofile.openapi.annotations.media.Content",
+      "contentType": "method-annotation"
     }
   },
   "@Content with Schema": {
@@ -39,7 +41,8 @@
     ],
     "description": "Provides schema and examples for a particular media type.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.media.Content"
+      "type": "org.eclipse.microprofile.openapi.annotations.media.Content",
+      "contentType": "method-annotation"
     }
   },
   "@Schema with implementation": {
@@ -51,7 +54,8 @@
     ],
     "description": "Allows the definition of input and output data types.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema"
+      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema",
+      "contentType": "method-annotation"
     }
   },
   "@Schema with type": {
@@ -63,7 +67,8 @@
     ],
     "description": "Allows the definition of input and output data types.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema"
+      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema",
+      "contentType": "method-annotation"
     }
   },
   "@Schema with implementation and type": {
@@ -78,7 +83,8 @@
     ],
     "description": "Allows the definition of input and output data types.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema"
+      "type": "org.eclipse.microprofile.openapi.annotations.media.Schema",
+      "contentType": "method-annotation"
     }
   },
   "@Parameters": {
@@ -93,7 +99,8 @@
     ],
     "description": "Encapsulates input parameters.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.parameters.Parameters"
+      "type": "org.eclipse.microprofile.openapi.annotations.parameters.Parameters",
+      "contentType": "method-annotation"
     }
   },
   "@Parameter": {
@@ -110,7 +117,8 @@
     ],
     "description": "Describes a single operation parameter.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.parameters.Parameter"
+      "type": "org.eclipse.microprofile.openapi.annotations.parameters.Parameter",
+      "contentType": "method-annotation"
     }
   },
   "@APIResponses": {
@@ -125,7 +133,8 @@
     ],
     "description": "A container for multiple responses from an API operation.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.responses.APIResponses"
+      "type": "org.eclipse.microprofile.openapi.annotations.responses.APIResponses",
+      "contentType": "method-annotation"
     }
   },
   "@APIResponse": {
@@ -142,7 +151,8 @@
     ],
     "description": "Describes a single response from an API operation.",
     "context": {
-      "type": "org.eclipse.microprofile.openapi.annotations.responses.APIResponse"
+      "type": "org.eclipse.microprofile.openapi.annotations.responses.APIResponse",
+      "contentType": "method-annotation"
     }
   }
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-restclient.json
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/resources/org/eclipse/lsp4mp/snippets/mp-restclient.json
@@ -24,7 +24,8 @@
     ],
     "description": "MicroProfile - new rest client",
     "context": {
-      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient"
+      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient",
+      "contentType": "class"
     }
   },
   "MicroProfile - inject rest client": {
@@ -32,7 +33,8 @@
     "body": ["@Inject", "@RestClient", "${1:Client} ${2:client};"],
     "description": "MicroProfile - inject rest client",
     "context": {
-      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient"
+      "type": "org.eclipse.microprofile.rest.client.inject.RegisterRestClient",
+      "contentType": "field"
     }
   }
 }


### PR DESCRIPTION
Snippet completion sends a request to the java language server to determine additional context based on the cursor location and content of the java file, then filters the snippets based on this context.

The context is fetched as a part of the existing `microprofile/java/completion` request.

This means that:
- snippets that generate class declarations (like `rest_class`, `mpreadiness`) only appear in empty files
- snippets that generate an annotation only appear when the cursor is in a class and before a declaration that the given annotation can be applied to.

This PR also removes code related to enabling/disabling the feature of getting the completion results directly from the JDT component.

Closes #108

Signed-off-by: David Thompson <davthomp@redhat.com>
