### PR TITLE
Fix diagnostics data deserialization

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtils.java
@@ -134,11 +134,18 @@ public class ArgumentUtils {
 		return null;
 	}
 
+	/**
+	 * Returns the child as a JsonObject if it exists and is an object, and null otherwise
+	 *
+	 * @param obj the object to get the child of
+	 * @param key the key of the child
+	 * @return the child as a JsonObject if it exists and is an object, and null otherwise
+	 */
 	public static JsonObject getObjectAsJson(Map<String, Object> obj, String key) {
 		Object child = obj.get(key);
 		if (child != null && child instanceof Map<?, ?>) {
 			Gson gson = new Gson();
-			return (JsonObject) gson.toJsonTree(obj);
+			return (JsonObject) gson.toJsonTree(child);
 		}
 		return null;
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtilsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/ArgumentUtilsTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core.ls;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Tests for {@link ArgumentUtils}.
+ */
+public class ArgumentUtilsTest {
+
+	private Map<String, Object> testMap;
+
+	@Before
+	public void setup() {
+		testMap = new HashMap<>();
+		HashMap<String, Object> childMap = new HashMap<>();
+		childMap.put("key", "value");
+		testMap.put("child", childMap);
+	}
+
+	@Test
+	public void testGetObjectAsJson() {
+		JsonObject obj = ArgumentUtils.getObjectAsJson(testMap, "child");
+		Assert.assertEquals(obj.keySet().size(), 1);
+		Assert.assertEquals(obj.get("key"), new JsonPrimitive("value"));
+	}
+
+	@Test
+	public void testGetObject() {
+		Map<String, Object> obj = ArgumentUtils.getObject(testMap, "child");
+		Assert.assertEquals(obj.keySet().size(), 1);
+		Assert.assertEquals(obj.get("key"), "value");
+	}
+
+}


### PR DESCRIPTION
Diagnostics data is used for some code actions, meaning bad deserialization causes the code actions to break. Added unit tests for the buggy helper method.

Fixes #303

Signed-off-by: David Thompson <davthomp@redhat.com>
