### PR TITLE
Prevent NPE when there are multiple definitions of a config property

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/utils/IConfigSourcePropertiesProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/utils/IConfigSourcePropertiesProvider.java
@@ -17,14 +17,14 @@ import java.util.Set;
 
 /**
  * Represents a config source that maps keys to values
- * 
+ *
  * @author datho7561
  */
 public interface IConfigSourcePropertiesProvider {
 
 	/**
 	 * Returns a set of all the keys that the config source defines.
-	 * 
+	 *
 	 * @return a set of all the keys that the config source defines
 	 */
 	Set<String> keys();
@@ -32,7 +32,7 @@ public interface IConfigSourcePropertiesProvider {
 	/**
 	 * Returns true if the config source defines a non-null non-empty value for the
 	 * given key, and false otherwise.
-	 * 
+	 *
 	 * @param key the key to check if this config source defines
 	 * @return true if the config source defines a non-null non-empty value for the
 	 *         given key, and false otherwise
@@ -40,10 +40,10 @@ public interface IConfigSourcePropertiesProvider {
 	boolean hasKey(String key);
 
 	/**
-	 * Returns the value of the property, or null if the property doens't have a value
-	 * 
+	 * Returns the value of the property, or null if the property doesn't have a value
+	 *
 	 * @param key the property key
-	 * @return the value of the property, or null if the property doens't have a value
+	 * @return the value of the property, or null if the property doesn't have a value
 	 */
 	String getValue(String key);
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/utils/PropertyValueExpander.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/utils/PropertyValueExpander.java
@@ -36,10 +36,10 @@ import io.smallrye.common.expression.Expression.Flag;
 /**
  * Expands property expressions to a final resolved value, while avoiding a few
  * pitfalls.
- * 
+ *
  * Checks for cycles before attempting expansion, and mitigates OOM due to
  * Billion Laughs by counting the number of variable references.
- * 
+ *
  * @author datho7561
  */
 public class PropertyValueExpander {
@@ -60,7 +60,7 @@ public class PropertyValueExpander {
 	/**
 	 * Returns the expanded value for the give key, or the unexpanded value if the
 	 * value can't be expanded.
-	 * 
+	 *
 	 * @param key the key to get the value of
 	 * @return the expanded value for the give key, or the unexpanded value if the
 	 *         value can't be expanded.
@@ -150,7 +150,7 @@ public class PropertyValueExpander {
 			// add edges
 			for (String key : properties.keys()) {
 				String unresolvedValue = properties.getValue(key);
-				if (unresolvedValue.contains("${")) {
+				if (StringUtils.hasText(unresolvedValue) && unresolvedValue.contains("${")) {
 					Expression expr = Expression.compile(unresolvedValue, Flag.LENIENT_SYNTAX);
 					expr.evaluate((resolver, builder) -> {
 						if (graph.nodes().contains(resolver.getKey())) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/utils/IConfigSourcePropertiesProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/utils/IConfigSourcePropertiesProvider.java
@@ -17,14 +17,14 @@ import java.util.Set;
 
 /**
  * Represents a config source that maps keys to values
- * 
+ *
  * @author datho7561
  */
 public interface IConfigSourcePropertiesProvider {
 
 	/**
 	 * Returns a set of all the keys that the config source defines.
-	 * 
+	 *
 	 * @return a set of all the keys that the config source defines
 	 */
 	Set<String> keys();
@@ -32,7 +32,7 @@ public interface IConfigSourcePropertiesProvider {
 	/**
 	 * Returns true if the config source defines a non-null non-empty value for the
 	 * given key, and false otherwise.
-	 * 
+	 *
 	 * @param key the key to check if this config source defines
 	 * @return true if the config source defines a non-null non-empty value for the
 	 *         given key, and false otherwise
@@ -40,10 +40,10 @@ public interface IConfigSourcePropertiesProvider {
 	boolean hasKey(String key);
 
 	/**
-	 * Returns the value of the property, or null if the property doens't have a value
-	 * 
+	 * Returns the value of the property, or null if the property doesn't have a value
+	 *
 	 * @param key the property key
-	 * @return the value of the property, or null if the property doens't have a value
+	 * @return the value of the property, or null if the property doesn't have a value
 	 */
 	String getValue(String key);
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/utils/PropertyValueExpander.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/utils/PropertyValueExpander.java
@@ -36,10 +36,10 @@ import io.smallrye.common.expression.Expression.Flag;
 /**
  * Expands property expressions to a final resolved value, while avoiding a few
  * pitfalls.
- * 
+ *
  * Checks for cycles before attempting expansion, and mitigates OOM due to
  * Billion Laughs by counting the number of variable references.
- * 
+ *
  * @author datho7561
  */
 public class PropertyValueExpander {
@@ -60,7 +60,7 @@ public class PropertyValueExpander {
 	/**
 	 * Returns the expanded value for the give key, or the unexpanded value if the
 	 * value can't be expanded.
-	 * 
+	 *
 	 * @param key the key to get the value of
 	 * @return the expanded value for the give key, or the unexpanded value if the
 	 *         value can't be expanded.
@@ -150,7 +150,7 @@ public class PropertyValueExpander {
 			// add edges
 			for (String key : properties.keys()) {
 				String unresolvedValue = properties.getValue(key);
-				if (unresolvedValue.contains("${")) {
+				if (StringUtils.hasText(unresolvedValue) && unresolvedValue.contains("${")) {
 					Expression expr = Expression.compile(unresolvedValue, Flag.LENIENT_SYNTAX);
 					expr.evaluate((resolver, builder) -> {
 						if (graph.nodes().contains(resolver.getKey())) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesInfoPropertiesProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesInfoPropertiesProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.lsp4mp.commons.utils.StringUtils;
 
 /**
  * Adapts a list of <code>ItemMetadata</code> to <code>IConfigSourcePropertiesProvider</code>
- * 
+ *
  * @author datho7561
  */
 class PropertiesInfoPropertiesProvider implements IConfigSourcePropertiesProvider {
@@ -63,7 +63,7 @@ class PropertiesInfoPropertiesProvider implements IConfigSourcePropertiesProvide
 			return null;
 		}
 		for (ItemMetadata item : properties) {
-			if (key.equals(item.getName())) {
+			if (key.equals(item.getName()) && StringUtils.hasText(item.getDefaultValue())) {
 				return item.getDefaultValue();
 			}
 		}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
@@ -363,6 +363,16 @@ public class PropertiesFileAssert {
 				expectedHoverOffset);
 	}
 
+	public static void assertHoverMarkdown(String value, String expectedHoverLabel, Integer expectedHoverOffset,
+			MicroProfileProjectInfo projectInfo)
+			throws BadLocationException, InterruptedException, TimeoutException, ExecutionException {
+		MicroProfileHoverSettings hoverSettings = new MicroProfileHoverSettings();
+		HoverCapabilities capabilities = new HoverCapabilities(Arrays.asList(MarkupKind.MARKDOWN), false);
+		hoverSettings.setCapabilities(capabilities);
+
+		assertHover(value, null, projectInfo, hoverSettings, expectedHoverLabel, expectedHoverOffset);
+	}
+
 	public static void assertHover(String value, String fileURI, MicroProfileProjectInfo projectInfo,
 			MicroProfileHoverSettings hoverSettings, String expectedHoverLabel, Integer expectedHoverOffset)
 			throws BadLocationException, InterruptedException, TimeoutException, ExecutionException {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileHoverTest.java
@@ -13,6 +13,11 @@ package org.eclipse.lsp4mp.services.properties;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.assertHoverMarkdown;
 import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.assertHoverPlaintext;
 
+import java.util.Arrays;
+
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
+import org.eclipse.lsp4mp.commons.metadata.ItemMetadata;
+import org.eclipse.lsp4mp.ls.commons.BadLocationException;
 import org.junit.Test;
 
 /**
@@ -213,6 +218,40 @@ public class PropertiesFileHoverTest {
 		// enum type
 		String hoverLabel = "**READ_UNCOMMITTED**" + System.lineSeparator();
 		assertHoverMarkdown(value, hoverLabel, 49);
+	}
+
+	@Test
+	public void hoverWithPropertyWithNullValue() throws Exception {
+		ItemMetadata appNameProperty = new ItemMetadata();
+		appNameProperty.setType("java.util.Optional\u003cjava.lang.String\u003e");
+		appNameProperty.setSourceField("name");
+		appNameProperty.setExtensionName("quarkus-core");
+		appNameProperty.setRequired(false);
+		appNameProperty.setPhase(2);
+		appNameProperty.setName("quarkus.application.name");
+		appNameProperty.setDescription("The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all).");
+		appNameProperty.setSourceType("io.quarkus.runtime.ApplicationConfig");
+
+		ItemMetadata propertyWithNullValue = new ItemMetadata();
+		propertyWithNullValue.setName("my.property");
+		propertyWithNullValue.setDefaultValue(null);
+
+		ItemMetadata propertyWithNotNullValue = new ItemMetadata();
+		propertyWithNotNullValue.setName("my.property");
+		propertyWithNotNullValue.setDefaultValue("asdf");
+
+		MicroProfileProjectInfo projectInfo = new MicroProfileProjectInfo();
+		projectInfo.setProperties(Arrays.asList(propertyWithNullValue, propertyWithNotNullValue, appNameProperty));
+
+		String value = "quarkus.applica|tion.name = name";
+		String hoverLabel = "**quarkus.application.name**" + System.lineSeparator() + System.lineSeparator() + //
+				"The name of the application.\nIf not set, defaults to the name of the project (except for tests where it is not set at all)."
+				+ System.lineSeparator() + System.lineSeparator() + //
+				" * Type: `java.util.Optional<java.lang.String>`" + System.lineSeparator() + //
+				" * Value: `name`" + System.lineSeparator() + //
+				" * Phase: `buildtime & runtime`" + System.lineSeparator() + //
+				" * Extension: `quarkus-core`";
+		assertHoverMarkdown(value, hoverLabel, 0, projectInfo);
 	}
 
 }


### PR DESCRIPTION
If a property is declared twice, once without a default value and once with, then one of the classes that adapts the properties list to a nicer interface would sometimes return the null default value instead of the non-null one.

Fixes #341

Signed-off-by: David Thompson <davthomp@redhat.com>
