### PR TITLE
Validate `defaultValue` for lists and arrays

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigErrorCode.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/MicroProfileConfigErrorCode.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaErrorCode;
  */
 public enum MicroProfileConfigErrorCode implements IJavaErrorCode {
 
-	NO_VALUE_ASSIGNED_TO_PROPERTY, DEFAULT_VALUE_IS_WRONG_TYPE, EMPTY_KEY;
+	NO_VALUE_ASSIGNED_TO_PROPERTY, DEFAULT_VALUE_IS_WRONG_TYPE, EMPTY_LIST_NOT_SUPPORTED, EMPTY_KEY;
 
 	@Override
 	public String getCode() {

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueListResource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueListResource.java
@@ -1,0 +1,41 @@
+package org.acme.config;
+
+import javax.ws.rs.Path;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.util.List;
+import java.util.Set;
+
+@Path("/greeting")
+public class DefaultValueListResource {
+
+    @ConfigProperty(name = "listprop1", defaultValue="foo")
+    List<Integer> greeting1;
+
+    @ConfigProperty(name = "listprop2", defaultValue="12,13,14")
+    List<Integer> greeting2;
+
+    @ConfigProperty(name = "listprop3", defaultValue="12,13,14")
+    int[] greeting3;
+
+    @ConfigProperty(name = "listprop4", defaultValue="12,13\\,14")
+    int[] greeting4;
+
+    @ConfigProperty(name = "listprop5", defaultValue="1")
+    List<Boolean> greeting5;
+
+    @ConfigProperty(name = "listprop6", defaultValue=",,,,,,,,")
+    Set<Boolean> greeting6;
+
+    @ConfigProperty(name = "listprop7", defaultValue="1.0,2.0,3.0")
+    float[] greeting7;
+
+    @ConfigProperty(name = "listprop8", defaultValue="AB,CD")
+    char[] greeting8;
+
+    @ConfigProperty(name = "listprop9", defaultValue=",,,,")
+    char[] greeting9;
+
+    @ConfigProperty(name = "listprop10", defaultValue="")
+    List<String> greeting10;
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueResource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueResource.java
@@ -33,4 +33,7 @@ public class DefaultValueResource {
     @ConfigProperty(name = "greeting9")
     String greeting9;
 
+    @ConfigProperty(name = "greeting10", defaultValue="AB")
+    char greeting10;
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
@@ -70,8 +70,47 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 				MicroProfileConfigErrorCode.NO_VALUE_ASSIGNED_TO_PROPERTY);
 		setDataForUnassigned("greeting9", d4);
 
+		Diagnostic d5 = d(35, 54, 58, "'AB' does not match the expected type of 'char'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
 		assertJavaDiagnostics(diagnosticsParams, utils, //
-				d1, d2, d3, d4);
+				d1, d2, d3, d4, d5);
+	}
+
+	@Test
+	public void improperDefaultValuesList() throws Exception {
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
+		IJDTUtils utils = JDT_UTILS;
+
+		MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+		IFile javaFile = javaProject.getProject()
+				.getFile(new Path("src/main/java/org/acme/config/DefaultValueListResource.java"));
+		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
+		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+		Diagnostic d1 = d(10, 53, 58, "'foo' does not match the expected type of 'List<Integer>'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
+		Diagnostic d2 = d(19, 53, 65, "'12,13\\,14' does not match the expected type of 'int[]'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
+		Diagnostic d3 = d(31, 53, 60, "'AB,CD' does not match the expected type of 'char[]'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
+		Diagnostic d4 = d(34, 53, 59, "',,,,' does not match the expected type of 'char[]'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
+		Diagnostic d5 = d(37, 54, 56, "'defaultValue=\"\"' will behave as if no default value is set, and will not be treated as an empty 'List<String>'.", DiagnosticSeverity.Warning,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.EMPTY_LIST_NOT_SUPPORTED);
+
+		assertJavaDiagnostics(diagnosticsParams, utils, //
+				d1, d2, d3, d4, d5);
 	}
 
 	@Test
@@ -98,8 +137,12 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
+		Diagnostic d4 = d(35, 54, 58, "'AB' does not match the expected type of 'char'.", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
 		assertJavaDiagnostics(diagnosticsParams, utils, //
-				d1, d2, d3);
+				d1, d2, d3, d4);
 	}
 
 	@Test

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/properties/ConfigItemIntBoolDefaultValueTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/properties/ConfigItemIntBoolDefaultValueTest.java
@@ -20,7 +20,6 @@ import static org.eclipse.lsp4mp.jdt.core.MicroProfileAssert.p;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
-import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest.MicroProfileMavenProjectName;
 import org.junit.Test;
 
 
@@ -38,11 +37,8 @@ public class ConfigItemIntBoolDefaultValueTest extends BasePropertiesManagerTest
 		MicroProfileProjectInfo infoFromClasspath = getMicroProfileProjectInfoFromMavenProject(
 				MicroProfileMavenProjectName.config_quickstart, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
 
-		String booleanDefault = "false";
-		String intDefault = "0";
-
 		assertProperties(infoFromClasspath,
-				20 /* properties from Java sources with ConfigProperty */ + //
+				31 /* properties from Java sources with ConfigProperty */ + //
 				7 /* static properties from microprofile-context-propagation-api */ + //
 				1 /* static property from microprofile config_ordinal */,
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/properties/MicroProfileConfigPropertyTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/properties/MicroProfileConfigPropertyTest.java
@@ -36,7 +36,7 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 		MicroProfileProjectInfo infoFromClasspath = getMicroProfileProjectInfoFromMavenProject(
 				MicroProfileMavenProjectName.config_quickstart, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
 
-		assertProperties(infoFromClasspath, 20 /* properties from Java sources with ConfigProperty */ + //
+		assertProperties(infoFromClasspath, 31 /* properties from Java sources with ConfigProperty */ + //
 				7 /* static properties from microprofile-context-propagation-api */ + //
 				1 /* static property from microprofile config_ordinal */,
 
@@ -95,7 +95,7 @@ public class MicroProfileConfigPropertyTest extends BasePropertiesManagerTest {
 		MicroProfileProjectInfo infoFromJavaSources = getMicroProfileProjectInfoFromMavenProject(
 				MicroProfileMavenProjectName.config_quickstart, MicroProfilePropertiesScope.ONLY_SOURCES);
 
-		assertProperties(infoFromJavaSources, 20 /* properties from Java sources with ConfigProperty */,
+		assertProperties(infoFromJavaSources, 31 /* properties from Java sources with ConfigProperty */,
 
 				// GreetingResource
 				// @ConfigProperty(name = "greeting.message")


### PR DESCRIPTION
- Fix a bug with validating `char` and `java.lang.Character`
- Add a new error message for list-like config properties that have `defaultValue=""`, since the TCK doesn't require this and smallrye-config doesn't support this

Fixes redhat-developer/vscode-microprofile#143

Signed-off-by: David Thompson <davthomp@redhat.com>
