### PR TITLE
Cancel delegate commands for workspace symbols

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -94,10 +94,13 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 							}
 						}
 
-					}, null);
+					}, monitor);
 		} catch (CoreException | ClassCastException e) {
 			LOGGER.log(Level.SEVERE,
 					"While collecting symbols for project " + project.getResource().getLocationURI().toString(), e);
+		}
+		if (monitor.isCanceled()) {
+			return;
 		}
 		annotatables
 				.forEach(annotatable -> collectSymbolFromAnnotatable(symbols, annotatable, applicationPrefix, utils));

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/utils/FutureUtils.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/utils/FutureUtils.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.utils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+
+/**
+ * Utilities for working with <code>CompletableFuture</code>s.
+ */
+public class FutureUtils {
+
+	/**
+	 * It's a copy of
+	 * {@link org.eclipse.lsp4j.jsonrpc.CompletableFutures#computeAsync} that
+	 * accepts a function that returns a CompletableFuture.
+	 *
+	 * @see CompletableFutures#computeAsync
+	 *
+	 * @param <R>  the return type of the asynchronous computation
+	 * @param code the code to run asynchronously
+	 * @return a future that sends the correct $/cancelRequest notification when
+	 *         canceled
+	 */
+	public static <R> CompletableFuture<R> computeAsyncCompose(Function<CancelChecker, CompletableFuture<R>> code) {
+		CompletableFuture<CancelChecker> start = new CompletableFuture<>();
+		CompletableFuture<R> result = start.thenComposeAsync(code);
+		start.complete(new CompletableFutures.FutureCancelChecker(result));
+		return result;
+	}
+
+}


### PR DESCRIPTION
When workspace symbol cancel is requested, cancel the delegate commands that compute the workspace symbols on the java language server side.

Signed-off-by: David Thompson <davthomp@redhat.com>
