### PR TITLE
Warning for GraphQL class without `@GraphQLApi`

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/graphql/MicroProfileGraphQLConstants.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/graphql/MicroProfileGraphQLConstants.java
@@ -22,8 +22,9 @@ public class MicroProfileGraphQLConstants {
 	}
 
 	public static final String QUERY_ANNOTATION = "org.eclipse.microprofile.graphql.Query";
-
 	public static final String MUTATION_ANNOTATION = "org.eclipse.microprofile.graphql.Mutation";
+
+	public static final String GRAPHQL_API_ANNOTATION = "org.eclipse.microprofile.graphql.GraphQLApi";
 
 	public static final String DIAGNOSTIC_SOURCE = "microprofile-graphql";
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/graphql/java/MicroProfileGraphQLErrorCode.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/graphql/java/MicroProfileGraphQLErrorCode.java
@@ -21,7 +21,8 @@ import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaErrorCode;
 public enum MicroProfileGraphQLErrorCode implements IJavaErrorCode {
 
 	NO_VOID_QUERIES,
-	NO_VOID_MUTATIONS
+	NO_VOID_MUTATIONS,
+	MISSING_GRAPHQL_API_ANNOTATION
 	;
 
 	@Override

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/WeatherService.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/WeatherService.java
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
 
-@GraphQLApi
 @ApplicationScoped
 public class WeatherService {
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/graphql/java/MicroProfileGraphQLValidationTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/graphql/java/MicroProfileGraphQLValidationTest.java
@@ -48,16 +48,22 @@ public class MicroProfileGraphQLValidationTest extends BasePropertiesManagerTest
 		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
 		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
 
-		Diagnostic d1 = d(89, 11, 15,
+		Diagnostic d1 = d(31, 13, 27,
+				"Annotate 'WeatherService' with '@GraphQLApi' in order for microprofile-graphql to recognize 'currentConditions' as a part of the GraphQL API.",
+				DiagnosticSeverity.Warning, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
+				MicroProfileGraphQLErrorCode.MISSING_GRAPHQL_API_ANNOTATION);
+
+		Diagnostic d2 = d(88, 11, 15,
 				"Methods annotated with microprofile-graphql's `@Query` cannot have 'void' as a return type.",
 				DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
 				MicroProfileGraphQLErrorCode.NO_VOID_QUERIES);
 
-		Diagnostic d2 = d(93, 11, 15,
+		Diagnostic d3 = d(92, 11, 15,
 				"Methods annotated with microprofile-graphql's `@Mutation` cannot have 'void' as a return type.",
 				DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
 				MicroProfileGraphQLErrorCode.NO_VOID_MUTATIONS);
+
 		assertJavaDiagnostics(diagnosticsParams, utils, //
-				d1, d2);
+				d1, d2, d3);
 	}
 }


### PR DESCRIPTION
If a class has methods annotated with `@Query` or `@Mutation`, but isn't annotated with `@GraphQLApi`, then a warning appears informing the programmer that microprofile-graphql won't add these methods to the GraphQL API.

Closes #355

Signed-off-by: David Thompson <davthomp@redhat.com>
