### PR TITLE
Extension point to customize JAX-RS features

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/schema/javaFeatureParticipants.exsd
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/schema/javaFeatureParticipants.exsd
@@ -26,6 +26,7 @@
                <element ref="definition" minOccurs="0" maxOccurs="unbounded"/>
                <element ref="hover" minOccurs="0" maxOccurs="unbounded"/>
                <element ref="workspaceSymbols" minOccurs="0" maxOccurs="unbounded"/>
+               <element ref="jaxrs" minOccurs="0" maxOccurs="unbounded"/>
             </choice>
          </sequence>
          <attribute name="point" type="string" use="required">
@@ -213,6 +214,26 @@
                </documentation>
                <appinfo>
                   <meta.attribute kind="java" basedOn=":org.eclipse.lsp4mp.jdt.core.java.symbol.IJavaWorkspaceSymbolsParticipant"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="jaxrs">
+      <annotation>
+         <documentation>
+            JAX-RS info provider.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Name of a class that implements IJaxRsInfoProvider
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider"/>
                </appinfo>
             </annotation>
          </attribute>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/HttpMethod.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/HttpMethod.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.jaxrs;
+
+/**
+ * Represents the HTTP methods that have specified semantics.
+ */
+public enum HttpMethod {
+	GET, //
+	HEAD, //
+	POST, //
+	PUT, //
+	DELETE, //
+	CONNECT, //
+	OPTIONS, //
+	TRACE, //
+	PATCH;
+
+	@Override
+	public String toString() {
+		return name();
+	}
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/IJaxRsInfoProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/IJaxRsInfoProvider.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.jaxrs;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+
+/**
+ * Provides a list of jax-rs methods in a project or file.
+ */
+public interface IJaxRsInfoProvider {
+
+	/**
+	 * Returns true if the provider can provide information on the JAX-RS methods in the given class and false otherwise.
+	 *
+	 * @param typeRoot the class to check
+	 * @param monitor the progress monitor
+	 * @return true if the provider can provide information on the JAX-RS methods in the given class and false otherwise
+	 */
+	public boolean canProvideJaxRsMethodInfoForClass(ITypeRoot typeRoot, IProgressMonitor monitor);
+
+	/**
+	 * Returns a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for.
+	 *
+	 * @param javaProject the project to check for JAX-RS method information
+	 * @param monitor the progress monitor
+	 * @return a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for
+	 */
+	public Set<ITypeRoot> getAllJaxRsClasses(IJavaProject javaProject, IProgressMonitor monitor);
+
+	/**
+	 * Returns a list of all the JAX-RS methods in the given type.
+	 *
+	 * @param type    the type to check for JAX-RS methods
+	 * @param monitor the progress monitor
+	 * @return a list of all the JAX-RS methods in the given type
+	 */
+	public List<JaxRsMethodInfo> getJaxRsMethodInfo(ITypeRoot typeRoot, JaxRsContext jaxrsContext, IJDTUtils utils, IProgressMonitor monitor);
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsConstants.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsConstants.java
@@ -11,7 +11,7 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package org.eclipse.lsp4mp.jdt.internal.jaxrs;
+package org.eclipse.lsp4mp.jdt.core.jaxrs;
 
 import java.util.Arrays;
 import java.util.List;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsMethodInfo.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsMethodInfo.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.core.jaxrs;
+
+import org.eclipse.jdt.core.IMethod;
+
+/**
+ * Represents a JAX-RS method.
+ */
+public class JaxRsMethodInfo {
+
+	private final String url;
+	private final HttpMethod httpMethod;
+	private final IMethod javaMethod;
+	private final String documentUri;
+
+	public JaxRsMethodInfo(String url, HttpMethod httpMethod, IMethod javaMethod, String documentUri) {
+		this.url = url;
+		this.javaMethod = javaMethod;
+		this.httpMethod = httpMethod;
+		this.documentUri = documentUri;
+	}
+
+	/**
+	 * Returns the URL of the JAX-RS method.
+	 *
+	 * @return the URL of the JAX-RS method
+	 */
+	public String getUrl() {
+		return this.url;
+	}
+
+	/**
+	 * Returns the HTTP method of the JAX-RS method.
+	 *
+	 * @return the HTTP method of the JAX-RS method
+	 */
+	public HttpMethod getHttpMethod() {
+		return this.httpMethod;
+	}
+
+	/**
+	 * Returns the Java method associated with this JAX-RS method.
+	 *
+	 * @return the Java method associated with this JAX-RS method
+	 */
+	public IMethod getJavaMethod() {
+		return this.javaMethod;
+	}
+
+	/**
+	 * Returns the URI of the Java file where this JAX-RS method is defined.
+	 *
+	 * @return the URI of the Java file where this JAX-RS method is defined
+	 */
+	public String getDocumentUri() {
+		return this.documentUri;
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/JaxRsUtils.java
@@ -13,17 +13,17 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.jaxrs;
 
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.HTTP_METHOD_ANNOTATIONS;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAKARTA_WS_RS_APPLICATIONPATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAKARTA_WS_RS_GET_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAKARTA_WS_RS_PATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAVAX_WS_RS_GET_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAVAX_WS_RS_PATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.PATH_VALUE;
 import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.getAnnotation;
 import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.getAnnotationMemberValue;
 import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.hasAnnotation;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.HTTP_METHOD_ANNOTATIONS;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAKARTA_WS_RS_APPLICATIONPATH_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAKARTA_WS_RS_GET_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAKARTA_WS_RS_PATH_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAVAX_WS_RS_APPLICATIONPATH_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAVAX_WS_RS_GET_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAVAX_WS_RS_PATH_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.PATH_VALUE;
 
 import java.util.Collections;
 
@@ -174,5 +174,38 @@ public class JaxRsUtils {
 			}
 		}
 		return url.toString();
+	}
+
+	/**
+	 * Returns an HttpMethod given the FQN of a JAX-RS or Jakarta RESTful
+	 * annotation, nor null if the FQN doesn't match any HttpMethod.
+	 *
+	 * @param annotationFQN the FQN of the annotation to convert into a HttpMethod
+	 * @return an HttpMethod given the FQN of a JAX-RS or Jakarta RESTful
+	 *         annotation, nor null if the FQN doesn't match any HttpMethod
+	 */
+	public static HttpMethod getHttpMethodForAnnotation(String annotationFQN) {
+		switch (annotationFQN) {
+		case JaxRsConstants.JAKARTA_WS_RS_GET_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_GET_ANNOTATION:
+			return HttpMethod.GET;
+		case JaxRsConstants.JAKARTA_WS_RS_HEAD_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_HEAD_ANNOTATION:
+			return HttpMethod.HEAD;
+		case JaxRsConstants.JAKARTA_WS_RS_POST_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_POST_ANNOTATION:
+			return HttpMethod.POST;
+		case JaxRsConstants.JAKARTA_WS_RS_PUT_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_PUT_ANNOTATION:
+			return HttpMethod.PUT;
+		case JaxRsConstants.JAKARTA_WS_RS_DELETE_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_DELETE_ANNOTATION:
+			return HttpMethod.DELETE;
+		case JaxRsConstants.JAKARTA_WS_RS_PATCH_ANNOTATION:
+		case JaxRsConstants.JAVAX_WS_RS_PATCH_ANNOTATION:
+			return HttpMethod.PATCH;
+		default:
+			return null;
+		}
 	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/JavaFeaturesRegistry.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/JavaFeaturesRegistry.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider;
 import org.eclipse.lsp4mp.jdt.internal.core.java.codeaction.JavaCodeActionDefinition;
 import org.eclipse.lsp4mp.jdt.internal.core.java.codelens.JavaCodeLensDefinition;
 import org.eclipse.lsp4mp.jdt.internal.core.java.completion.JavaCompletionDefinition;
@@ -31,6 +32,7 @@ import org.eclipse.lsp4mp.jdt.internal.core.java.definition.JavaDefinitionDefini
 import org.eclipse.lsp4mp.jdt.internal.core.java.diagnostics.JavaDiagnosticsDefinition;
 import org.eclipse.lsp4mp.jdt.internal.core.java.hover.JavaHoverDefinition;
 import org.eclipse.lsp4mp.jdt.internal.core.java.symbols.JavaWorkspaceSymbolsDefinition;
+import org.eclipse.lsp4mp.jdt.internal.jaxrs.java.DefaultJaxRsInfoProvider;
 
 /**
  * Registry to hold the extension point
@@ -47,6 +49,7 @@ public class JavaFeaturesRegistry {
 	private static final String DIAGNOSTICS_ELT = "diagnostics";
 	private static final String HOVER_ELT = "hover";
 	private static final String WORKSPACE_SYMBOLS_ELT = "workspaceSymbols";
+	private static final String JAXRS_ELT = "jaxrs";
 
 	private static final Logger LOGGER = Logger.getLogger(JavaFeaturesRegistry.class.getName());
 
@@ -66,6 +69,8 @@ public class JavaFeaturesRegistry {
 
 	private final List<JavaWorkspaceSymbolsDefinition> javaWorkspaceSymbolsDefinitions;
 
+	private final List<IJaxRsInfoProvider> jaxRsInfoProviders;
+
 	private boolean javaFeatureDefinitionsLoaded;
 
 	public static JavaFeaturesRegistry getInstance() {
@@ -81,6 +86,7 @@ public class JavaFeaturesRegistry {
 		javaDiagnosticsDefinitions = new ArrayList<>();
 		javaHoverDefinitions = new ArrayList<>();
 		javaWorkspaceSymbolsDefinitions = new ArrayList<>();
+		jaxRsInfoProviders = new ArrayList<>();
 	}
 
 	/**
@@ -154,6 +160,16 @@ public class JavaFeaturesRegistry {
 		return javaWorkspaceSymbolsDefinitions;
 	}
 
+	/**
+	 * Returns a list of JAX-RS info providers.
+	 *
+	 * @return a list of JAX-RS info providers
+	 */
+	public List<IJaxRsInfoProvider> getJaxRsInfoProviders() {
+		loadJavaFeatureDefinitions();
+		return jaxRsInfoProviders;
+	}
+
 	private synchronized void loadJavaFeatureDefinitions() {
 		if (javaFeatureDefinitionsLoaded)
 			return;
@@ -166,6 +182,7 @@ public class JavaFeaturesRegistry {
 		IConfigurationElement[] cf = registry.getConfigurationElementsFor(MicroProfileCorePlugin.PLUGIN_ID,
 				EXTENSION_JAVA_FEATURE_PARTICIPANTS);
 		addJavaFeatureDefinition(cf);
+		jaxRsInfoProviders.add(new DefaultJaxRsInfoProvider());
 	}
 
 	private void addJavaFeatureDefinition(IConfigurationElement[] cf) {
@@ -227,9 +244,16 @@ public class JavaFeaturesRegistry {
 			synchronized (javaWorkspaceSymbolsDefinitions) {
 				javaWorkspaceSymbolsDefinitions.add(definition);
 			}
+			break;
+		}
+		case JAXRS_ELT : {
+			JaxRsInfoDefinition definition = new JaxRsInfoDefinition(ce);
+			synchronized (jaxRsInfoProviders) {
+				jaxRsInfoProviders.add(definition);
+			}
+			break;
 		}
 		default:
-
 		}
 	}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/JaxRsInfoDefinition.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/JaxRsInfoDefinition.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.core.java;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsContext;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsMethodInfo;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+
+/**
+ * Wrapper class around {@link IJaxRsInfoProvider}
+ */
+public class JaxRsInfoDefinition extends AbstractJavaFeatureDefinition<IJaxRsInfoProvider> implements IJaxRsInfoProvider {
+
+	private static final Logger LOGGER = Logger.getLogger(JaxRsInfoDefinition.class.getName());
+
+	public JaxRsInfoDefinition(IConfigurationElement element) {
+		super(element);
+	}
+
+	@Override
+	public boolean canProvideJaxRsMethodInfoForClass(ITypeRoot typeRoot, IProgressMonitor monitor) {
+		try {
+			return getParticipant().canProvideJaxRsMethodInfoForClass(typeRoot, monitor);
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "Unable to get JAX-RS info provider", e);
+			return false;
+		}
+	}
+
+	@Override
+	public Set<ITypeRoot> getAllJaxRsClasses(IJavaProject javaProject, IProgressMonitor monitor) {
+		try {
+			return getParticipant().getAllJaxRsClasses(javaProject, monitor);
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "Unable to get JAX-RS info provider", e);
+			return Collections.emptySet();
+		}
+	}
+
+	@Override
+	public List<JaxRsMethodInfo> getJaxRsMethodInfo(ITypeRoot typeRoot, JaxRsContext context, IJDTUtils utils, IProgressMonitor monitor) {
+		try {
+			return getParticipant().getJaxRsMethodInfo(typeRoot, context, utils, monitor);
+		} catch (Exception e) {
+			LOGGER.log(Level.SEVERE, "Unable to get JAX-RS info provider", e);
+			return Collections.emptyList();
+		}
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/DefaultJaxRsInfoProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/DefaultJaxRsInfoProvider.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+* Copyright (c) 2023 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp.jdt.internal.jaxrs.java;
+
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAKARTA_WS_RS_PATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants.JAVAX_WS_RS_PATH_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.getJaxRsPathValue;
+import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.isJaxRsRequestMethod;
+import static org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.hasAnnotation;
+import static org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils.overlaps;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.core.search.BasicSearchEngine;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.HttpMethod;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsContext;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsMethodInfo;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils;
+import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
+import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
+
+/**
+ * Locates JAX-RS methods in a project or class file using the default semantics.
+ */
+public class DefaultJaxRsInfoProvider implements IJaxRsInfoProvider {
+
+	private static final Logger LOGGER = Logger.getLogger(DefaultJaxRsInfoProvider.class.getName());
+
+	private static final SearchPattern SEARCH_PATTERN;
+	static {
+		SearchPattern leftPattern = null;
+		for (String annotation : JaxRsConstants.HTTP_METHOD_ANNOTATIONS) {
+			if (leftPattern == null) {
+				leftPattern = annotationSearchPattern(annotation);
+			} else {
+				leftPattern = SearchPattern.createOrPattern(leftPattern, annotationSearchPattern(annotation));
+			}
+		}
+		SEARCH_PATTERN = leftPattern;
+	}
+
+	@Override
+	public boolean canProvideJaxRsMethodInfoForClass(ITypeRoot typeRoot, IProgressMonitor monitor) {
+		IJavaProject javaProject = typeRoot.getJavaProject();
+		return JDTTypeUtils.findType(javaProject, JAVAX_WS_RS_PATH_ANNOTATION) == null
+				|| JDTTypeUtils.findType(javaProject, JAKARTA_WS_RS_PATH_ANNOTATION) == null;
+
+	}
+
+	@Override
+	public Set<ITypeRoot> getAllJaxRsClasses(IJavaProject javaProject, IProgressMonitor monitor) {
+		if (monitor.isCanceled()) {
+			return Collections.emptySet();
+		}
+		Set<ITypeRoot> jaxRsClasses = new HashSet<>();
+		SearchEngine engine = new SearchEngine();
+		IJavaSearchScope scope = BasicSearchEngine.createJavaSearchScope(true, new IJavaElement[] { javaProject },
+				IJavaSearchScope.SOURCES);
+
+		try {
+			engine.search(SEARCH_PATTERN, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, scope,
+					new SearchRequestor() {
+
+						@Override
+						public void acceptSearchMatch(SearchMatch match) throws CoreException {
+							if (match.isInsideDocComment()) {
+								return;
+							}
+
+							if (match.getElement() instanceof IJavaElement element) {
+								jaxRsClasses.add(getTypeRoot(element));
+							}
+						}
+
+					}, monitor);
+		} catch (CoreException | ClassCastException e) {
+			LOGGER.log(Level.SEVERE, "While collecting JAX-RS method information for project "
+					+ javaProject.getResource().getLocationURI().toString(), e);
+		}
+		if (monitor.isCanceled()) {
+			return Collections.emptySet();
+		}
+		return jaxRsClasses;
+	}
+
+	@Override
+	public List<JaxRsMethodInfo> getJaxRsMethodInfo(ITypeRoot typeRoot, JaxRsContext jaxrsContext, IJDTUtils utils,
+			IProgressMonitor monitor) {
+		List<JaxRsMethodInfo> methodInfos = new ArrayList<>();
+		try {
+			collectJaxRsMethodInfo(typeRoot.getChildren(), null, methodInfos, jaxrsContext, utils, monitor);
+		} catch (CoreException e) {
+			LOGGER.log(Level.SEVERE, "while collecting JAX-RS method info using the default method", e);
+		}
+		return methodInfos;
+	}
+
+	private static void collectJaxRsMethodInfo(IJavaElement[] elements, String rootPath,
+			Collection<JaxRsMethodInfo> jaxRsMethodsInfo, JaxRsContext jaxrsContext, IJDTUtils utils,
+			IProgressMonitor monitor) throws JavaModelException, CoreException {
+
+		for (IJavaElement element : elements) {
+			if (monitor.isCanceled()) {
+				return;
+			}
+			if (element.getElementType() == IJavaElement.TYPE) {
+				IType type = (IType) element;
+				// Get value of JAX-RS @Path annotation from the class
+				String pathValue = getJaxRsPathValue(type);
+				if (pathValue != null) {
+					// Class is annotated with @Path
+					// Loop for each method annotated with @Path to generate
+					// URL code lens per
+					// method.
+					collectJaxRsMethodInfo(type.getChildren(), pathValue, jaxRsMethodsInfo, jaxrsContext, utils,
+							monitor);
+				}
+				continue;
+			} else if (element.getElementType() == IJavaElement.METHOD) {
+				if (utils.isHiddenGeneratedElement(element)) {
+					continue;
+				}
+				// ignore element if method range overlaps the type range,
+				// happens for generated
+				// bytecode, i.e. with lombok
+				IJavaElement parentType = element.getAncestor(IJavaElement.TYPE);
+				if (parentType != null && overlaps(((ISourceReference) parentType).getNameRange(),
+						((ISourceReference) element).getNameRange())) {
+					continue;
+				}
+			} else {// neither a type nor a method, we bail
+				continue;
+			}
+
+			// Here java element is a method
+			if (rootPath != null) {
+				IMethod method = (IMethod) element;
+				// A JAX-RS method is a public method annotated with @GET @POST,
+				// @DELETE, @PUT
+				// JAX-RS
+				// annotation
+				if (isJaxRsRequestMethod(method) && Flags.isPublic(method.getFlags())) {
+					String baseURL = jaxrsContext.getLocalBaseURL();
+					JaxRsMethodInfo info = createJaxRsMethodInfo(baseURL, rootPath, method, utils);
+					if (info != null) {
+						jaxRsMethodsInfo.add(info);
+					}
+				}
+			}
+		}
+	}
+
+	private static final SearchPattern annotationSearchPattern(String annotationFQN) {
+		return SearchPattern.createPattern(annotationFQN, IJavaSearchConstants.ANNOTATION_TYPE,
+				IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE, SearchPattern.R_EXACT_MATCH);
+	}
+
+	private static ITypeRoot getTypeRoot(IJavaElement element) {
+		ICompilationUnit cu = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
+		if (cu != null) {
+			return cu;
+		}
+		return (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
+	}
+
+	/**
+	 * Returns the JAX-RS method information for the given Java method using the
+	 * default JAX-RS semantics.
+	 *
+	 * @param baseURL  the base URL.
+	 * @param rootPath the JAX-RS path value.
+	 * @param method   the method to build the JAX-RS method information out of
+	 * @param utils    the jdt utils
+	 * @return the JAX-RS method information for the given Java method using the
+	 *         default JAX-RS semantics
+	 * @throws JavaModelException if something does wrong while calculating the HTTP
+	 *                            method or resolving the URL
+	 */
+	private static JaxRsMethodInfo createJaxRsMethodInfo(String baseUrl, String rootPath, IMethod method,
+			IJDTUtils utils) throws JavaModelException {
+		IResource resource = method.getResource();
+		if (resource == null) {
+			return null;
+		}
+		String documentUri = resource.getLocationURI().toString();
+
+		HttpMethod httpMethod = null;
+		for (String methodAnnotationFQN : JaxRsConstants.HTTP_METHOD_ANNOTATIONS) {
+			if (hasAnnotation(method, methodAnnotationFQN)) {
+				httpMethod = JaxRsUtils.getHttpMethodForAnnotation(methodAnnotationFQN);
+				break;
+			}
+		}
+		if (httpMethod == null) {
+			return null;
+		}
+
+		String pathValue = getJaxRsPathValue(method);
+		String url = JaxRsUtils.buildURL(baseUrl, rootPath, pathValue);
+
+		return new JaxRsMethodInfo(url, httpMethod, method, documentUri);
+	}
+
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsCodeLensParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsCodeLensParticipant.java
@@ -13,38 +13,35 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.internal.jaxrs.java;
 
-import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.createURLCodeLens;
-import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.getJaxRsPathValue;
-import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.isClickableJaxRsRequestMethod;
-import static org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils.isJaxRsRequestMethod;
-import static org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils.overlaps;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAKARTA_WS_RS_PATH_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants.JAVAX_WS_RS_PATH_ANNOTATION;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.ISourceReference;
-import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.lsp4j.CodeLens;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
 import org.eclipse.lsp4mp.jdt.core.java.codelens.IJavaCodeLensParticipant;
 import org.eclipse.lsp4mp.jdt.core.java.codelens.JavaCodeLensContext;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.HttpMethod;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider;
 import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsContext;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsMethodInfo;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
+import org.eclipse.lsp4mp.jdt.internal.core.java.JavaFeaturesRegistry;
 
 /**
  *
@@ -54,6 +51,8 @@ import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
  *
  */
 public class JaxRsCodeLensParticipant implements IJavaCodeLensParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(JaxRsCodeLensParticipant.class.getName());
 
 	private static final String LOCALHOST = "localhost";
 
@@ -65,10 +64,10 @@ public class JaxRsCodeLensParticipant implements IJavaCodeLensParticipant {
 		if (!params.isUrlCodeLensEnabled()) {
 			return false;
 		}
-		// Collection of URL codeLens is done only if JAX-RS is on the classpath
-		IJavaProject javaProject = context.getJavaProject();
-		return JDTTypeUtils.findType(javaProject, JAVAX_WS_RS_PATH_ANNOTATION) != null
-				|| JDTTypeUtils.findType(javaProject, JAKARTA_WS_RS_PATH_ANNOTATION) != null;
+
+		ITypeRoot typeRoot = context.getTypeRoot();
+		// if some jaxrs info provider can provide jaxrs method info for this class, provide lens
+		return getProviderForType(typeRoot, monitor) != null;
 	}
 
 	@Override
@@ -79,73 +78,32 @@ public class JaxRsCodeLensParticipant implements IJavaCodeLensParticipant {
 	@Override
 	public List<CodeLens> collectCodeLens(JavaCodeLensContext context, IProgressMonitor monitor) throws CoreException {
 		ITypeRoot typeRoot = context.getTypeRoot();
-		IJavaElement[] elements = typeRoot.getChildren();
 		JaxRsContext jaxrsContext = JaxRsContext.getJaxRsContext(context);
 		IJDTUtils utils = context.getUtils();
-		MicroProfileJavaCodeLensParams params = context.getParams();
-		List<CodeLens> lenses = new ArrayList<>();
-		collectURLCodeLenses(elements, null, lenses, params, jaxrsContext, utils, monitor);
-		return lenses;
-	}
 
-	private static void collectURLCodeLenses(IJavaElement[] elements, String rootPath, Collection<CodeLens> lenses,
-			MicroProfileJavaCodeLensParams params, JaxRsContext jaxrsContext, IJDTUtils utils, IProgressMonitor monitor)
-			throws JavaModelException, CoreException {
-
-		for (IJavaElement element : elements) {
-			if (monitor.isCanceled()) {
-				return;
-			}
-			if (element.getElementType() == IJavaElement.TYPE) {
-				IType type = (IType) element;
-				// Get value of JAX-RS @Path annotation from the class
-				String pathValue = getJaxRsPathValue(type);
-				if (pathValue != null) {
-					// Class is annotated with @Path
-					// Display code lens only if local server is available.
-					if (!params.isCheckServerAvailable()
-							|| isServerAvailable(LOCALHOST, jaxrsContext.getServerPort(), PING_TIMEOUT)) {
-						// Loop for each method annotated with @Path to generate
-						// URL code lens per
-						// method.
-						collectURLCodeLenses(type.getChildren(), pathValue, lenses, params, jaxrsContext, utils,
-								monitor);
-					}
-				}
-				continue;
-			} else if (element.getElementType() == IJavaElement.METHOD) {
-				if (utils.isHiddenGeneratedElement(element)) {
-					continue;
-				}
-				// ignore element if method range overlaps the type range,
-				// happens for generated
-				// bytecode, i.e. with lombok
-				IJavaElement parentType = element.getAncestor(IJavaElement.TYPE);
-				if (parentType != null && overlaps(((ISourceReference) parentType).getNameRange(),
-						((ISourceReference) element).getNameRange())) {
-					continue;
-				}
-			} else {// neither a type nor a method, we bail
-				continue;
-			}
-
-			// Here java element is a method
-			if (rootPath != null) {
-				IMethod method = (IMethod) element;
-				// A JAX-RS method is a public method annotated with @GET @POST,
-				// @DELETE, @PUT
-				// JAX-RS
-				// annotation
-				if (isJaxRsRequestMethod(method) && Flags.isPublic(method.getFlags())) {
-					String baseURL = jaxrsContext.getLocalBaseURL();
-					String openURICommandId = isClickableJaxRsRequestMethod(method) ? params.getOpenURICommand() : null;
-					CodeLens lens = createURLCodeLens(baseURL, rootPath, openURICommandId, (IMethod) element, utils);
-					if (lens != null) {
-						lenses.add(lens);
-					}
-				}
-			}
+		if (context.getParams().isCheckServerAvailable()
+				&& !isServerAvailable(LOCALHOST, jaxrsContext.getServerPort(), PING_TIMEOUT)) {
+			return Collections.emptyList();
 		}
+
+		IJaxRsInfoProvider provider = getProviderForType(typeRoot, monitor);
+		if (provider == null) {
+			return Collections.emptyList();
+		}
+		List<JaxRsMethodInfo> infos = provider.getJaxRsMethodInfo(typeRoot, jaxrsContext, utils, monitor);
+
+		MicroProfileJavaCodeLensParams params = context.getParams();
+		return infos.stream() //
+				.map(methodInfo -> {
+					try {
+						return createCodeLens(methodInfo, params.getOpenURICommand(), utils);
+					} catch (Exception e) {
+						LOGGER.log(Level.WARNING, "failed to create codelens for jax-rs method", e);
+						return null;
+					}
+				}) //
+				.filter(lens -> lens != null) //
+				.collect(Collectors.toList());
 	}
 
 	private static boolean isServerAvailable(String host, int port, int timeout) {
@@ -156,4 +114,65 @@ public class JaxRsCodeLensParticipant implements IJavaCodeLensParticipant {
 			return false;
 		}
 	}
+
+	/**
+	 * Returns the provider that can provide JAX-RS method info for the given class,
+	 * or null if no provider can provide info.
+	 *
+	 * @param typeRoot the class to collect JAX-RS method info for
+	 * @param monitor the progress monitor
+	 * @return the provider that can provide JAX-RS method info for the given class,
+	 *         or null if no provider can provide info
+	 */
+	private static IJaxRsInfoProvider getProviderForType(ITypeRoot typeRoot, IProgressMonitor monitor) {
+		for (IJaxRsInfoProvider provider : JavaFeaturesRegistry.getInstance().getJaxRsInfoProviders()) {
+			if (provider.canProvideJaxRsMethodInfoForClass(typeRoot, monitor)) {
+				return provider;
+			}
+		}
+		LOGGER.severe("Attempted to collect JAX-RS info for " + typeRoot.getElementName()
+				+ ", but no participant was suitable, despite the fact that an earlier check found a suitable participant");
+		return null;
+	}
+
+	/**
+	 * Returns a code lens for the given JAX-RS method information.
+	 *
+	 * @param methodInfo       the JAX-RS method information to build the code lens
+	 *                         out of
+	 * @param openUriCommandId the id of the client command to invoke to open a URL
+	 *                         in the browser
+	 * @param utils            the jdt utils
+	 * @return a code lens for the given JAX-RS method information
+	 * @throws JavaModelException if something goes wrong calculating the range
+	 */
+	private static CodeLens createCodeLens(JaxRsMethodInfo methodInfo, String openUriCommandId, IJDTUtils utils)
+			throws JavaModelException {
+		CodeLens lens = new CodeLens();
+
+		IMethod method = methodInfo.getJavaMethod();
+		IAnnotation[] annotations = method.getAnnotations();
+		if (annotations == null) {
+			return null;
+		}
+		ISourceRange r = annotations[annotations.length - 1].getSourceRange();
+
+		Range range = utils.toRange(method.getOpenable(), r.getOffset(), r.getLength());
+		// Increment line number for code lens to appear on the line right after the
+		// last annotation
+		Position codeLensPosition = new Position(range.getEnd().getLine() + 1, range.getEnd().getCharacter());
+		range.setStart(codeLensPosition);
+		range.setEnd(codeLensPosition);
+
+		lens.setRange(range);
+		lens.setCommand(new Command(methodInfo.getUrl(), //
+				isHttpMethodClickable(methodInfo.getHttpMethod()) && openUriCommandId != null ? openUriCommandId : "", //
+				Collections.singletonList(methodInfo.getUrl())));
+		return lens;
+	}
+
+	private static boolean isHttpMethodClickable(HttpMethod httpMethod) {
+		return HttpMethod.GET.equals(httpMethod);
+	}
+
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -13,42 +13,30 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.internal.jaxrs.java;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IAnnotatable;
-import org.eclipse.jdt.core.IAnnotation;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.search.IJavaSearchConstants;
-import org.eclipse.jdt.core.search.IJavaSearchScope;
-import org.eclipse.jdt.core.search.SearchEngine;
-import org.eclipse.jdt.core.search.SearchMatch;
-import org.eclipse.jdt.core.search.SearchParticipant;
-import org.eclipse.jdt.core.search.SearchPattern;
-import org.eclipse.jdt.core.search.SearchRequestor;
-import org.eclipse.jdt.internal.core.search.BasicSearchEngine;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
-import org.eclipse.lsp4mp.jdt.core.MicroProfileCorePlugin;
 import org.eclipse.lsp4mp.jdt.core.java.symbols.IJavaWorkspaceSymbolsParticipant;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.IJaxRsInfoProvider;
 import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsContext;
-import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsUtils;
-import org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsMethodInfo;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants;
-import org.eclipse.lsp4mp.jdt.internal.restclient.MicroProfileRestClientConstants;
+import org.eclipse.lsp4mp.jdt.internal.core.java.JavaFeaturesRegistry;
 
 /**
  * Collects workspace symbols for JAX-RS REST endpoints.
@@ -57,196 +45,85 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 
 	private static final Logger LOGGER = Logger.getLogger(JaxRsWorkspaceSymbolParticipant.class.getName());
 
-	private static final SearchPattern SEARCH_PATTERN;
-	static {
-		SearchPattern leftPattern = null;
-		for (String annotation : JaxRsConstants.HTTP_METHOD_ANNOTATIONS) {
-			if (leftPattern == null) {
-				leftPattern = annotationSearchPattern(annotation);
-			} else {
-				leftPattern = SearchPattern.createOrPattern(leftPattern, annotationSearchPattern(annotation));
-			}
-		}
-		SEARCH_PATTERN = leftPattern;
-	}
-
 	@Override
 	public void collectSymbols(IJavaProject project, IJDTUtils utils, List<SymbolInformation> symbols, IProgressMonitor monitor) {
 		if (monitor.isCanceled()) {
 			return;
 		}
-		String applicationPrefix = getJaxApplicationPath(project);
-		SearchEngine engine = new SearchEngine();
-		IJavaSearchScope scope = BasicSearchEngine.createJavaSearchScope(true, new IJavaElement[] { project },
-				IJavaSearchScope.SOURCES);
-		Set<IAnnotatable> annotatables = new HashSet<>();
-		try {
-			engine.search(SEARCH_PATTERN, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, scope,
-					new SearchRequestor() {
 
-						@Override
-						public void acceptSearchMatch(SearchMatch match) throws CoreException {
-							if (match.isInsideDocComment()) {
-								return;
-							}
-
-							if (match.getElement() instanceof IAnnotation) {
-								annotatables.add((IAnnotatable) ((IAnnotation) match.getElement()).getParent());
-							} else if (match.getElement() instanceof IAnnotatable) {
-								annotatables.add((IAnnotatable) match.getElement());
-							}
-						}
-
-					}, monitor);
-		} catch (CoreException | ClassCastException e) {
-			LOGGER.log(Level.SEVERE,
-					"While collecting symbols for project " + project.getResource().getLocationURI().toString(), e);
-		}
+		JaxRsContext jaxrsContext = new JaxRsContext(project);
+		Set<ITypeRoot> jaxrsTypes = getAllJaxRsTypes(project, monitor);
 		if (monitor.isCanceled()) {
 			return;
 		}
-		annotatables
-				.forEach(annotatable -> collectSymbolFromAnnotatable(symbols, annotatable, applicationPrefix, utils));
-	}
-
-	private void collectSymbolFromAnnotatable(List<SymbolInformation> symbols, IAnnotatable annotatable,
-			String applicationPrefix, IJDTUtils utils) {
-
-		if (!(annotatable instanceof IMethod)) {
-			return;
-		}
-
-		IMethod method = (IMethod) annotatable;
-		try {
-			if (!Flags.isPublic(method.getFlags())) {
+		List<JaxRsMethodInfo> methodsInfo = new ArrayList<>();
+		for (ITypeRoot typeRoot : jaxrsTypes) {
+			IJaxRsInfoProvider provider = getProviderForType(typeRoot, monitor);
+			if (provider != null) {
+				methodsInfo.addAll(provider.getJaxRsMethodInfo(typeRoot, jaxrsContext, utils, monitor));
+			}
+			if (monitor.isCanceled()) {
 				return;
 			}
-		} catch (JavaModelException e) {
-			return;
 		}
 
-		String endpointUri = getEndpointUriFromAnnotatable(annotatable, applicationPrefix);
-		String httpMethods = getHttpMethodsFromAnnotatable(annotatable);
-		if (endpointUri == null || endpointUri.isEmpty() || httpMethods.isEmpty()) {
-			return;
-		}
+		methodsInfo.forEach(methodInfo -> {
+			try {
+				symbols.add(createSymbol(methodInfo, utils));
+			} catch (Exception e) {
+				LOGGER.log(Level.WARNING, "failed to create workspace symbol for jax-rs method", e);
+			}
+		});
+	}
 
-		Location location = getLocationFromAnnotatable(method, utils);
-		if (location == null) {
-			return;
+	/**
+	 * Returns the provider that can provide JAX-RS method info for the given class,
+	 * or null if no provider can provide info.
+	 *
+	 * @param typeRoot the class to collect JAX-RS method info for
+	 * @param monitor the progress monitor
+	 * @return the provider that can provide JAX-RS method info for the given class,
+	 *         or null if no provider can provide info
+	 */
+	private static IJaxRsInfoProvider getProviderForType(ITypeRoot typeRoot, IProgressMonitor monitor) {
+		for (IJaxRsInfoProvider provider : JavaFeaturesRegistry.getInstance().getJaxRsInfoProviders()) {
+			if (provider.canProvideJaxRsMethodInfoForClass(typeRoot, monitor)) {
+				return provider;
+			}
 		}
+		LOGGER.severe("Attempted to collect JAX-RS info for " + typeRoot.getElementName()
+				+ ", but no participant was suitable, despite the fact that an earlier check found a suitable participant");
+		return null;
+	}
+
+	private static Set<ITypeRoot> getAllJaxRsTypes(IJavaProject javaProject, IProgressMonitor monitor) {
+		Set<ITypeRoot> jaxrsTypes = new HashSet<>();
+		for (IJaxRsInfoProvider provider : JavaFeaturesRegistry.getInstance().getJaxRsInfoProviders()) {
+			jaxrsTypes.addAll(provider.getAllJaxRsClasses(javaProject, monitor));
+			if (monitor.isCanceled()) {
+				return null;
+			}
+		}
+		return jaxrsTypes;
+	}
+
+	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IJDTUtils utils) throws JavaModelException, MalformedURLException {
+		ISourceRange sourceRange = methodInfo.getJavaMethod().getNameRange();
+		Range r = utils.toRange(methodInfo.getJavaMethod().getOpenable(), sourceRange.getOffset(), sourceRange.getLength());
+		Location location = new Location(methodInfo.getDocumentUri(), r);
 
 		StringBuilder nameBuilder = new StringBuilder("@");
-		nameBuilder.append(endpointUri);
+		URL url = new URL(methodInfo.getUrl());
+		String path = url.getPath();
+		nameBuilder.append(path);
 		nameBuilder.append(": ");
-		nameBuilder.append(httpMethods);
+		nameBuilder.append(methodInfo.getHttpMethod());
 
 		SymbolInformation symbol = new SymbolInformation();
 		symbol.setName(nameBuilder.toString());
 		symbol.setKind(SymbolKind.Method);
 		symbol.setLocation(location);
-
-		symbols.add(symbol);
-	}
-
-	private static Location getLocationFromAnnotatable(IMethod method, IJDTUtils utils) {
-		try {
-			String uri = method.getResource().getLocationURI().toString();
-			ISourceRange r = method.getNameRange();
-			Range range = utils.toRange(method.getOpenable(), r.getOffset(), r.getLength());
-			if (range == null) {
-				return null;
-			}
-			return new Location(uri, range);
-		} catch (JavaModelException e) {
-			return null;
-		}
-	}
-
-	private static String getEndpointUriFromAnnotatable(IAnnotatable annotatable, String applicationPrefix) {
-		StringBuilder builder = new StringBuilder();
-		IAnnotatable current = annotatable;
-
-		while (current != null && current != (IAnnotatable) ((IJavaElement) current).getAncestor(IJavaElement.TYPE)) {
-			if (hasRestClientAnnotation(current)) {
-				// This is not an endpoint, it's an interface to an outside service
-				return null;
-			}
-			prependPathSegment(builder, current);
-			current = (IAnnotatable) ((IJavaElement) current).getAncestor(IJavaElement.TYPE);
-		}
-		if (hasRestClientAnnotation(current)) {
-			return null;
-		}
-		if (current != null) {
-			prependPathSegment(builder, current);
-		}
-		if (applicationPrefix != null) {
-			builder.insert(0, applicationPrefix);
-			if (applicationPrefix.charAt(0) != '/') {
-				builder.insert(0, '/');
-			}
-		}
-		return builder.toString();
-	}
-
-	private static void prependPathSegment(StringBuilder builder, IAnnotatable current) {
-		String pathValue = null;
-		try {
-			pathValue = JaxRsUtils.getJaxRsPathValue(current);
-		} catch (JavaModelException e) {
-		}
-		if (pathValue != null) {
-			builder.insert(0, pathValue);
-			if (pathValue.charAt(0) != '/') {
-				builder.insert(0, "/");
-			}
-		}
-	}
-
-	private static String getHttpMethodsFromAnnotatable(IAnnotatable annotatable) {
-		StringBuilder builder = new StringBuilder();
-		for (String methodName : JaxRsConstants.HTTP_METHOD_ANNOTATIONS) {
-			if (hasAnnotation(annotatable, methodName)) {
-				if (builder.isEmpty()) {
-					builder.append(methodName.substring(methodName.lastIndexOf('.') + 1));
-				} else {
-					builder.append("|");
-					builder.append(methodName.substring(methodName.lastIndexOf('.') + 1));
-				}
-			}
-		}
-		return builder.toString();
-	}
-
-	private static final SearchPattern annotationSearchPattern(String annotationFQN) {
-		return SearchPattern.createPattern(annotationFQN, IJavaSearchConstants.ANNOTATION_TYPE,
-				IJavaSearchConstants.ANNOTATION_TYPE_REFERENCE, SearchPattern.R_EXACT_MATCH);
-	}
-
-	private static boolean hasRestClientAnnotation(IAnnotatable annotatable) {
-		return hasAnnotation(annotatable, MicroProfileRestClientConstants.REGISTER_REST_CLIENT_ANNOTATION);
-	}
-
-	private static boolean hasAnnotation(IAnnotatable annotatable, String annotationSimpleName) {
-		try {
-			return AnnotationUtils.hasAnnotation(annotatable, annotationSimpleName);
-		} catch (JavaModelException e) {
-			return false;
-		}
-	}
-
-	private static String getJaxApplicationPath(IJavaProject project) {
-		JaxRsContext jaxContext = new JaxRsContext(project);
-		try {
-			String prefix = jaxContext.getApplicationPath(null);
-			if (prefix == null || prefix.isEmpty()) {
-				return null;
-			}
-			return prefix;
-		} catch (CoreException e) {
-			return null;
-		}
+		return symbol;
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/openapi/java/OpenAPIAnnotationProposal.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/openapi/java/OpenAPIAnnotationProposal.java
@@ -35,7 +35,7 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4mp.jdt.core.java.corrections.proposal.ASTRewriteCorrectionProposal;
-import org.eclipse.lsp4mp.jdt.internal.jaxrs.JaxRsConstants;
+import org.eclipse.lsp4mp.jdt.core.jaxrs.JaxRsConstants;
 import org.eclipse.lsp4mp.jdt.internal.openapi.MicroProfileOpenAPIConstants;
 
 /**

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsApplicationPathCodeLensTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsApplicationPathCodeLensTest.java
@@ -13,19 +13,17 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.jaxrs.java;
 
-import java.util.List;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertCodeLens;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.cl;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
-import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -53,7 +51,7 @@ public class JaxRsApplicationPathCodeLensTest extends BasePropertiesManagerTest 
 				"public class MyApplication extends Application {}\r\n", javaProject, true);
 
 		// Default port
-		assertCodeLense(8080, params, utils, "/api/path");
+		assertCodeLenses(8080, params, utils, "/api/path");
 	}
 
 	@Test
@@ -75,7 +73,7 @@ public class JaxRsApplicationPathCodeLensTest extends BasePropertiesManagerTest 
 				"public class MyApplication extends Application {}\r\n", javaProject, true);
 
 		// Default port
-		assertCodeLense(8080, params, utils, "/api/path");
+		assertCodeLenses(8080, params, utils, "/api/path");
 	}
 
 	@Test
@@ -97,7 +95,7 @@ public class JaxRsApplicationPathCodeLensTest extends BasePropertiesManagerTest 
 				"public class MyApplication extends Application {}\r\n", javaProject, true);
 
 		// Default port
-		assertCodeLense(8080, params, utils, "/api/path");
+		assertCodeLenses(8080, params, utils, "/api/path");
 
 		saveFile("org/acme/MyApplication.java", "package org.acme;\r\n" + //
 				"import javax.ws.rs.ApplicationPath;\r\n" + //
@@ -105,7 +103,7 @@ public class JaxRsApplicationPathCodeLensTest extends BasePropertiesManagerTest 
 				"@ApplicationPath(\"/ipa\")\r\n" + //
 				"public class MyApplication extends Application {}\r\n", javaProject, true);
 
-		assertCodeLense(8080, params, utils, "/ipa/path");
+		assertCodeLenses(8080, params, utils, "/ipa/path");
 	}
 
 	@Test
@@ -119,18 +117,14 @@ public class JaxRsApplicationPathCodeLensTest extends BasePropertiesManagerTest 
 		params.setUri(javaFile.getLocation().toFile().toURI().toString());
 		params.setUrlCodeLensEnabled(true);
 
-		assertCodeLense(8080, params, utils, "/api/api/resource");
+		assertCodeLens(params, utils, //
+				cl("http://localhost:8080/api/api/resource", "", r(13, 5, 5)));
 	}
 
-	private static void assertCodeLense(int port, MicroProfileJavaCodeLensParams params, IJDTUtils utils,
+	private static void assertCodeLenses(int port, MicroProfileJavaCodeLensParams params, IJDTUtils utils,
 			String actualEndpoint) throws JavaModelException {
-		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
-				new NullProgressMonitor());
-		Assert.assertEquals(1, lenses.size());
-
-		CodeLens lenseForEndpoint = lenses.get(0);
-		Assert.assertNotNull(lenseForEndpoint.getCommand());
-		Assert.assertEquals("http://localhost:" + port + actualEndpoint, lenseForEndpoint.getCommand().getTitle());
+		assertCodeLens(params, utils, //
+				cl("http://localhost:" + port + actualEndpoint, "", r(12, 35, 35)));
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsCodeLensTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsCodeLensTest.java
@@ -13,21 +13,17 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.jaxrs.java;
 
-import java.util.List;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertCodeLens;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.cl;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.lsp4j.CodeLens;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCodeLensParams;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
-import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -70,55 +66,13 @@ public class JaxRsCodeLensTest extends BasePropertiesManagerTest {
 		assertCodeLenses(8080, params, utils);
 	}
 
-	private static void assertCodeLenses(int port, MicroProfileJavaCodeLensParams params, IJDTUtils utils)
-			throws JavaModelException {
-		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
-				new NullProgressMonitor());
-		Assert.assertEquals(5, lenses.size());
-
-		// @GET
-		// public Fruit[] get() {
-		CodeLens lensForGet = lenses.get(0);
-		Assert.assertNotNull(lensForGet.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits", lensForGet.getCommand().getTitle());
-
-		// @GET
-		// @Path("{id}")
-		// public Fruit getSingle(@PathParam Integer id) {
-		CodeLens lensForGetSingle = lenses.get(1);
-		Assert.assertNotNull(lensForGetSingle.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits/{id}", lensForGetSingle.getCommand().getTitle());
-
-		//@POST
-		//public Response create(Fruit fruit) {
-		CodeLens lensForPost = lenses.get(2);
-		Assert.assertNotNull(lensForPost.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits", lensForPost.getCommand().getTitle());
-
-		//@PUT
-		//@Path("{id}")
-		//public Fruit update(@PathParam Integer id, Fruit fruit) {
-		CodeLens lensForPut = lenses.get(3);
-		Assert.assertNotNull(lensForPut.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits/{id}", lensForPut.getCommand().getTitle());
-
-		//@DELETE
-		//@Transactional
-		//@Path(
-		//"{id}"
-		//)
-		//--> code lens should appear here
-		//public
-		//Response
-		//delete(@PathParam Integer id) {
-		CodeLens lensForDelete = lenses.get(4);
-		Assert.assertNotNull(lensForDelete.getCommand());
-		Assert.assertEquals("http://localhost:" + port + "/fruits/{id}", lensForDelete.getCommand().getTitle());
-		Assert.assertEquals(r(81, 9, 81, 9), lensForDelete.getRange());
-	}
-	
-	public static Range r(int startLine, int startCharacter, int endLine, int endCharacter) {
-		return new Range(new Position(startLine, startCharacter), new Position(endLine, endCharacter));
+	private static void assertCodeLenses(int port, MicroProfileJavaCodeLensParams params, IJDTUtils utils) throws JavaModelException {
+		assertCodeLens(params, utils, //
+				cl("http://localhost:" + port + "/fruits", "", r(31, 8, 8)), //
+				cl("http://localhost:" + port + "/fruits/{id}", "", r(38, 17, 17)), //
+				cl("http://localhost:" + port + "/fruits", "", r(48, 18, 18)), //
+				cl("http://localhost:" + port + "/fruits/{id}", "", r(60, 18, 18)), //
+				cl("http://localhost:" + port + "/fruits/{id}", "", r(81, 9, 9)));
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsWorkspaceSymbolParticipantTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/jaxrs/java/JaxRsWorkspaceSymbolParticipantTest.java
@@ -13,23 +13,12 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.jaxrs.java;
 
-import static org.junit.Assert.assertEquals;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertWorkspaceSymbols;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.si;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
-import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
-import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
-import org.eclipse.lsp4mp.jdt.core.utils.JDTMicroProfileUtils;
 import org.junit.Test;
 
 /**
@@ -37,63 +26,25 @@ import org.junit.Test;
  */
 public class JaxRsWorkspaceSymbolParticipantTest extends BasePropertiesManagerTest {
 
-	private static IProgressMonitor NULL_MONITOR = new NullProgressMonitor();
-
 	@Test
 	public void testConfigQuickstart() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
-		IJDTUtils utils = JDT_UTILS;
-		String projectUri = JDTMicroProfileUtils.getProjectURI(javaProject);
 
-		List<SymbolInformation> actual = PropertiesManagerForJava.getInstance().workspaceSymbols(projectUri, utils, NULL_MONITOR);
-
-		assertWorkspaceSymbols(Arrays.asList( //
-				si("@/greeting/hello4: GET", 40, 18, 40, 24), si("@/greeting/constructor: GET", 34, 18, 34, 23),
-				si("@/greeting/hello: GET", 33, 18, 33, 24), si("@/greeting: GET", 26, 18, 26, 23),
-				si("@/greeting/method: GET", 38, 18, 38, 23), si("@/greeting/hello5: PATCH", 46, 18, 46, 24)), actual);
+		assertWorkspaceSymbols(javaProject, JDT_UTILS, //
+				si("@/greeting/hello4: GET", r(40, 18, 24)), //
+				si("@/greeting/constructor: GET", r(34, 18, 23)), //
+				si("@/greeting/hello: GET", r(33, 18, 24)), //
+				si("@/greeting: GET", r(26, 18, 23)), //
+				si("@/greeting/method: GET", r(38, 18, 23)), //
+				si("@/greeting/hello5: PATCH", r(46, 18, 24)));
 	}
 
 	@Test
 	public void testOpenLiberty() throws Exception {
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.open_liberty);
-		IJDTUtils utils = JDT_UTILS;
-		String projectUri = JDTMicroProfileUtils.getProjectURI(javaProject);
 
-		List<SymbolInformation> actual = PropertiesManagerForJava.getInstance().workspaceSymbols(projectUri, utils, NULL_MONITOR);
-
-		assertWorkspaceSymbols(Arrays.asList( //
-				si("@/api/api/resource: GET", 13, 15, 13, 20)), actual);
+		assertWorkspaceSymbols(javaProject, JDT_UTILS, //
+				si("@/api/api/resource: GET", r(13, 15, 20)));
 	}
 
-	private static void assertWorkspaceSymbols(List<SymbolInformation> expected, List<SymbolInformation> actual) {
-		assertEquals(expected.size(), actual.size());
-		Collections.sort(expected, (si1, si2) -> si1.getName().compareTo(si2.getName()));
-		Collections.sort(actual, (si1, si2) -> si1.getName().compareTo(si2.getName()));
-		for (int i = 0; i < expected.size(); i++) {
-			assertSymbolInformation(expected.get(i), actual.get(i));
-		}
-	}
-
-	/**
-	 * Asserts that the expected and actual symbol informations' name and range are
-	 * the same.
-	 *
-	 * Doesn't check any of the other properties.
-	 *
-	 * @param expected the expected symbol information
-	 * @param actual   the actual symbol information
-	 */
-	private static void assertSymbolInformation(SymbolInformation expected, SymbolInformation actual) {
-		assertEquals(expected.getName(), actual.getName());
-		assertEquals(expected.getLocation().getRange(), actual.getLocation().getRange());
-	}
-
-	private static SymbolInformation si(String name, int startLine, int startChar, int endLine, int endChar) {
-		SymbolInformation symbolInformation = new SymbolInformation();
-		symbolInformation.setName(name);
-		Range range = new Range(new Position(startLine, startChar), new Position(endLine, endChar));
-		Location location = new Location("", range);
-		symbolInformation.setLocation(location);
-		return symbolInformation;
-	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/java/MicroProfileRestClientJavaCodeLensTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/restclient/java/MicroProfileRestClientJavaCodeLensTest.java
@@ -13,6 +13,10 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.restclient.java;
 
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.assertCodeLens;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.cl;
+import static org.eclipse.lsp4mp.jdt.core.MicroProfileForJavaAssert.r;
+
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -120,7 +124,7 @@ public class MicroProfileRestClientJavaCodeLensTest extends BasePropertiesManage
 				javaProject);
 		assertCodeLenses("https://restcountries.url/${org.acme.restclient.CountriesService/mp-rest/url}", params,
 				utils);
-		
+
 		// /mp-rest/uri
 		// double reference
 		saveFile(MicroProfileConfigSourceProvider.MICROPROFILE_CONFIG_PROPERTIES_FILE,
@@ -189,65 +193,15 @@ public class MicroProfileRestClientJavaCodeLensTest extends BasePropertiesManage
 
 	private static void assertCodeLenses(String baseURL, MicroProfileJavaCodeLensParams params, IJDTUtils utils)
 			throws JavaModelException {
-		List<? extends CodeLens> lenses = PropertiesManagerForJava.getInstance().codeLens(params, utils,
-				new NullProgressMonitor());
-		Assert.assertEquals(8, lenses.size());
-
-		// @GET
-		// @Path("/name/{name}")
-		// Set<Country> getByName(@PathParam String name);
-		CodeLens lensForGet = lenses.get(0);
-		Assert.assertNotNull(lensForGet.getCommand());
-		Assert.assertEquals(baseURL + "/v2/name/{name}", lensForGet.getCommand().getTitle());
-
-		// @GET
-		// @Path("/name/{name}")
-		// CompletionStage<Set<Country>> getByNameAsync(@PathParam String name);
-		CodeLens lensForGetSingle = lenses.get(1);
-		Assert.assertNotNull(lensForGetSingle.getCommand());
-		Assert.assertEquals(baseURL + "/v2/name/{name}", lensForGetSingle.getCommand().getTitle());
-		
-		// @POST
-		// @Path("/post")
-		// String post();
-		CodeLens lensForPost = lenses.get(2);
-		Assert.assertNotNull(lensForPost.getCommand());
-		Assert.assertEquals(baseURL + "/v2/post", lensForPost.getCommand().getTitle());
-		
-		// @PUT
-		// @Path("/put")
-		// String put();
-		CodeLens lensForPut = lenses.get(3);
-		Assert.assertNotNull(lensForPut.getCommand());
-		Assert.assertEquals(baseURL + "/v2/put", lensForPut.getCommand().getTitle());
-		
-		// @DELETE
-		// @Path("/delete")
-		// String delete();
-		CodeLens lensForDelete = lenses.get(4);
-		Assert.assertNotNull(lensForDelete.getCommand());
-		Assert.assertEquals(baseURL + "/v2/delete", lensForDelete.getCommand().getTitle());
-
-		// @HEAD
-		// @Path("/head")
-		// String head();
-		CodeLens lensForHead = lenses.get(5);
-		Assert.assertNotNull(lensForHead.getCommand());
-		Assert.assertEquals(baseURL + "/v2/head", lensForHead.getCommand().getTitle());
-
-		// @OPTIONS
-		// @Path("/options")
-		// String options();
-		CodeLens lensForOptions = lenses.get(6);
-		Assert.assertNotNull(lensForOptions.getCommand());
-		Assert.assertEquals(baseURL + "/v2/options", lensForOptions.getCommand().getTitle());
-
-		// @PATCH
-		// @Path("/patch")
-		// String patch();
-		CodeLens lensForPatch = lenses.get(7);
-		Assert.assertNotNull(lensForPatch.getCommand());
-		Assert.assertEquals(baseURL + "/v2/patch", lensForPatch.getCommand().getTitle());
+		assertCodeLens(params, utils, //
+				cl(baseURL + "/v2/name/{name}", "", r(24, 33, 33)), //
+				cl(baseURL + "/v2/name/{name}", "", r(29, 33, 33)), //
+				cl(baseURL + "/v2/post", "", r(33, 18, 18)), //
+				cl(baseURL + "/v2/put", "", r(37, 17, 17)), //
+				cl(baseURL + "/v2/delete", "", r(41, 20, 20)), //
+				cl(baseURL + "/v2/head", "", r(45, 18, 18)), //
+				cl(baseURL + "/v2/options", "", r(49, 21, 21)), //
+				cl(baseURL + "/v2/patch", "", r(53, 19, 19)));
 	}
 
 }


### PR DESCRIPTION
Allows you to customize the JAX-RS/Jakarta RESTful features using a new extension point. lsp4mp uses any implementations of `IJaxRsInfoParticipant` that are contributed through external extensions onto lsp4mp in order to collect a list of all classes that contain JAX-RS methods. When collecting JAX-RS methods for a given class file, lsp4mp uses the first `IJaxRsInfoParticipant` that reports it is able to collect JAX-RS methods for a given class in order to do so. If no `IJaxRsInfoParticipant` can resolve JAX-RS methods for a class, it uses the default semantics for resolving JAX-RS methods.

This way, if you are working within a framework that uses custom logic for determining which methods are REST endpoints, or custom logic for what the corresponding URLs are for those endpoints, lsp4mp can support that use case through additional contributed logic.

Signed-off-by: David Thompson <davthomp@redhat.com>
