### PR TITLE
Fix NPE on shutdown when LSP client doesn't define extendedClientCapabilities

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileLanguageServer.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/MicroProfileLanguageServer.java
@@ -166,9 +166,9 @@ public class MicroProfileLanguageServer implements LanguageServer, ProcessLangua
 
 	@Override
 	public CompletableFuture<Object> shutdown() {
-		if (capabilityManager.getClientCapabilities().getExtendedCapabilities().shouldLanguageServerExitOnShutdown()) {
+		if (capabilityManager.getClientCapabilities().shouldLanguageServerExitOnShutdown()) {
 			ScheduledExecutorService delayer = Executors.newScheduledThreadPool(1);
-			delayer.schedule(() -> exit(0) , 1, TimeUnit.SECONDS);
+			delayer.schedule(() -> exit(0), 1, TimeUnit.SECONDS);
 		}
 		return computeAsync(cc -> new Object());
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -101,8 +101,17 @@ public class ClientCapabilitiesWrapper {
 		return this.capabilities.getWorkspace();
 	}
 
-	public ExtendedClientCapabilities getExtendedCapabilities() {
-		return extendedCapabilities;
+	/**
+	 * Returns true if the client should exit on shutdown() request and avoid
+	 * waiting for an exit() request
+	 *
+	 * @return true if the language server should exit on shutdown() request
+	 */
+	public boolean shouldLanguageServerExitOnShutdown() {
+		if (extendedCapabilities == null) {
+			return false;
+		}
+		return extendedCapabilities.shouldLanguageServerExitOnShutdown();
 	}
 
 	public boolean isResourceOperationSupported() {


### PR DESCRIPTION
.In [JBossTools Quarkus](https://github.com/jbosstools/jbosstools-quarkus) they don't define the extendedClientCapabilities which cause an NPE when the MP LS is shutdown.

This PR fixes this problem. The code is the same than Qute Language Server.