### PR TITLE
Fix definition for property value of user-defined class

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManager.java
@@ -471,7 +471,7 @@ public class PropertiesManager {
 	public Location findPropertyLocation(IJavaProject javaProject, String sourceType, String sourceField,
 			String sourceMethod, IJDTUtils utils, IProgressMonitor progress) throws JavaModelException, CoreException {
 		IMember fieldOrMethod = findProperty(javaProject, sourceType, sourceField, sourceMethod, utils, progress);
-		if (fieldOrMethod != null) {
+		if (fieldOrMethod != null && fieldOrMethod.exists()) {
 			return utils.toLocation(fieldOrMethod);
 		}
 		return null;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerLocationTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerLocationTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest.MicroProfileMavenProjectName;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -93,6 +94,31 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 				JDT_UTILS, new NullProgressMonitor());
 
 		Assert.assertNotNull("Definition from GreetingConstructorResource constructor", location);
+	}
+
+	@Test
+	public void nonExistantFieldTest() throws Exception {
+		// Use case:
+		// In the properties file we have the following:
+		// ```properties
+		// my.fruit=Banana
+		// ```
+		//
+		// In a Java file, we have `my.fruit` defined as:
+		// ```java
+		// @ConfigProperty(name="my.fruit") public org.acme.vertx.Fruit myFruit;
+		// ```
+		//
+		// Because of this, we are expecting class "Fruit" to be an enum, but it is a
+		// POJO.
+		// When we attempt to locate the enum value `Banana`, it returns a handle to a
+		// non-existent field, which we must ignore.
+
+		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.using_vertx);
+
+		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject, "org.acme.vertx.Fruit",
+				"Banana", null, JDT_UTILS, new NullProgressMonitor());
+		Assert.assertNull(location);
 	}
 
 	private static void enableClassFileContentsSupport() {


### PR DESCRIPTION
Prevent an Exception when finding the definition of a property value by checking if the field that the value refers to actually exists in the compilation unit before trying to get its source range.

Fixes #374

Signed-off-by: David Thompson <davthomp@redhat.com>
