### PR TITLE
Update eclipse.jdt.ls to 1.24.0-SNAPSHOT

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -24,7 +24,7 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
     <surefire.timeout>600</surefire.timeout>
-    <jdt.ls.version>1.23.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.24.0-SNAPSHOT</jdt.ls.version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>


### PR DESCRIPTION
See https://github.com/eclipse/eclipse.jdt.ls/pull/2666 . m2e 2.3.0 snapshot repo is gone so the old JDT-LS TP won't build. Need to use a newer one.