### PR TITLE
Remove unnecessary fields in properties file completion result

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/CompletionData.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/CompletionData.java
@@ -34,8 +34,7 @@ public class CompletionData {
 		this.uri = null;
 	}
 
-	public CompletionData(String propertyName, String uri) {
-		this.propertyName = propertyName;
+	public CompletionData(String uri) {
 		this.uri = uri;
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileCompletions.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileCompletions.java
@@ -171,7 +171,7 @@ class PropertiesFileCompletions {
 	 */
 	public CompletionItem resolveCompletionItem(CompletionItem unresolved, MicroProfileProjectInfo projectInfo,
 			MicroProfileCompletionCapabilities completionCapabilities, CancelChecker cancelChecker) {
-		String propertyName = CompletionData.getCompletionData(unresolved).getPropertyName();
+		String propertyName = unresolved.getLabel();
 		boolean markdownSupported = completionCapabilities.isDocumentationFormatSupported(MarkupKind.MARKDOWN);
 		ItemMetadata property = PropertiesFileUtils.getProperty(propertyName, projectInfo);
 		if (property == null) {
@@ -267,9 +267,6 @@ class PropertiesFileCompletions {
 			FormattedPropertyResult formattedProperty = getPropertyName(name, snippetsSupported);
 			insertText.append(formattedProperty.getPropertyName());
 
-			String filterText = insertText.toString();
-			item.setFilterText(filterText);
-
 			if (formattingSettings.isSurroundEqualsWithSpaces()) {
 				insertText.append(' ');
 			}
@@ -315,7 +312,7 @@ class PropertiesFileCompletions {
 				item.setInsertTextFormat(snippetsSupported ? InsertTextFormat.Snippet : InsertTextFormat.PlainText);
 			}
 			if (completionResolveDocumentationSupported) {
-				item.setData(new CompletionData(propertyName, model.getDocumentURI()));
+				item.setData(new CompletionData(model.getDocumentURI()));
 			} else {
 				item.setDocumentation(DocumentationUtils.getDocumentation(property, profile, null, markdownSupported));
 			}
@@ -381,11 +378,10 @@ class PropertiesFileCompletions {
 					|| completionItemDefaults.getInsertTextFormat() != InsertTextFormat.PlainText) {
 				item.setInsertTextFormat(InsertTextFormat.PlainText);
 			}
-			item.setFilterText(insertText);
 			if (completionResolveDocumentationSupported) {
 				for (ValueHint profile : QuarkusModel.DEFAULT_PROFILES.getValues()) {
 					if (profile.getValue().equals(item.getLabel())) {
-						item.setData(new CompletionData(key.getPropertyName(), model.getDocumentURI()));
+						item.setData(new CompletionData(model.getDocumentURI()));
 						break;
 					}
 				}


### PR DESCRIPTION
Fixes #410

* This PR removes `filterText` and `data.propertyName` where `label` is used instead
* `CompletionData.uri` is left since vscode client (not sure about intellij or other clients) does not support `itemDefaults.data` indicated by client capabilities.

These are the supported fields for `itemDefaults` in vscode:
```
                "completionList": {
                    "itemDefaults": [
                        "commitCharacters",
                        "editRange",
                        "insertTextFormat",
                        "insertTextMode"
                    ]
                }
```

Here is an example of the completion item result after the change: 
```
        {
            "label": "quarkus.cache.enabled",
            "kind": 10,
            "textEditText": "quarkus.cache.enabled=${1|false,true|}",
            "data": {
                "uri": "file:///home/jhe/Projects/test_files/quarkus-quickstarts/cache-quickstart/src/main/resources/application.properties"
            }
        },
```