### PR TITLE
Update eclipse.jdt.ls to 1.27.0-SNAPSHOT

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -15,7 +15,7 @@
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
     <tycho.test.platformArgs />
-    <tycho.test.jvmArgs>-Xmx512m ${tycho.test.platformArgs}</tycho.test.jvmArgs>
+    <tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true ${tycho.test.platformArgs}</tycho.test.jvmArgs>
 
     <!-- Code coverage -->
     <jacoco.version>0.8.8</jacoco.version>
@@ -24,7 +24,7 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
     <surefire.timeout>600</surefire.timeout>
-    <jdt.ls.version>1.25.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.27.0-SNAPSHOT</jdt.ls.version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>


### PR DESCRIPTION
- Automatic JVM detection in JDT Debug seems to have introduced a regression in JDT indexing causing java.lang.OutOfMemory, so use DetectVMInstallationsJob.disabled=true property from JDT Debug

I noticed the OOM issue when running locally. If it isn't happening on the Eclipse builds, it's likely because the JDK version that is causing it, is not present.