### PR TITLE
Handle throwables in project info retrieval.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/MicroProfileDelegateCommandHandler.java
@@ -117,12 +117,13 @@ public class MicroProfileDelegateCommandHandler extends AbstractMicroProfileDele
 			LOGGER.log(Level.WARNING, "Error while joining MicroProfile properties collector job", e);
 		}
 
-		Exception jobException = (Exception) job.getResult().getException();
+		Throwable jobException = job.getResult().getException();
 		if (jobException != null) {
-			if (jobException.getCause() != null) {
-				throw (Exception) jobException.getCause();
+			if (jobException instanceof Exception) {
+				throw (Exception) jobException;
+			} else {
+				throw new Exception(jobException);
 			}
-			throw jobException;
 		}
 
 		return projectInfo[0];


### PR DESCRIPTION
- Errors like java.lang.StackOverflowError can be encountered
- Rethrow as a regular exception containing the relevant message, or just the fully qualified name of the exception
- Fixes https://github.com/eclipse/lsp4mp/issues/418

So instead of seeing :

```
!ENTRY org.eclipse.jdt.ls.core 4 2 2023-08-22 15:09:46.706
!MESSAGE Problems occurred when invoking code from plug-in: "org.eclipse.jdt.ls.core".
!STACK 0
java.lang.ClassCastException: class java.lang.StackOverflowError cannot be cast to class java.lang.Exception (java.lang.StackOverflowError and java.lang.Exception are in module java.base of loader 'bootstrap')
	at org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler.getMicroProfileProjectInfo(MicroProfileDelegateCommandHandler.java:120)
	at org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler.executeCommand(MicroProfileDelegateCommandHandler.java:58)
	at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler$1.run(WorkspaceExecuteCommandHandler.java:230)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler.executeCommand(WorkspaceExecuteCommandHandler.java:220)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$4(JDTLanguageServer.java:599)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```

which "technically" does expose the issue but only by telling you it failed to appropriately cast, you'll see :

```
!ENTRY org.eclipse.jdt.ls.core 4 0 2023-08-22 15:01:35.773
!MESSAGE Error in calling delegate command handler
!STACK 0
java.lang.Exception: java.lang.StackOverflowError
	at org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler.getMicroProfileProjectInfo(MicroProfileDelegateCommandHandler.java:127)
	at org.eclipse.lsp4mp.jdt.internal.core.ls.MicroProfileDelegateCommandHandler.executeCommand(MicroProfileDelegateCommandHandler.java:58)
	at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler$1.run(WorkspaceExecuteCommandHandler.java:230)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
	at org.eclipse.jdt.ls.core.internal.handlers.WorkspaceExecuteCommandHandler.executeCommand(WorkspaceExecuteCommandHandler.java:220)
	at org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer.lambda$4(JDTLanguageServer.java:599)
	at org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer.lambda$0(BaseJDTLanguageServer.java:87)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
```

(Note that the StackOverflowError didn't contain an actual message, though maybe there's errors that would contain that)