### PR TITLE
fix: use newer JDT.LS's JavadocContentAccess2 methods

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/JDTUtilsLSImpl.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/ls/JDTUtilsLSImpl.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
-import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess;
+import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2;
 import org.eclipse.jdt.ls.core.internal.managers.IBuildSupport;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
@@ -131,8 +131,8 @@ public class JDTUtilsLSImpl implements IJDTUtils {
 	@Override
 	public String getJavadoc(IMember member, DocumentFormat documentFormat) throws JavaModelException {
 		boolean markdown = DocumentFormat.Markdown.equals(documentFormat);
-		Reader reader = markdown ? JavadocContentAccess.getMarkdownContentReader(member)
-				: JavadocContentAccess.getPlainTextContentReader(member);
+		Reader reader = markdown ? JavadocContentAccess2.getMarkdownContentReader(member)
+				: JavadocContentAccess2.getPlainTextContentReader(member);
 		return reader != null ? toString(reader) : null;
 	}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
@@ -22,6 +22,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -34,6 +35,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
@@ -135,7 +137,9 @@ public class BasePropertiesManagerTest {
 	}
 
 	public static IJavaProject loadGradleProject(String gradleProject) throws CoreException, Exception {
-		return loadJavaProject(gradleProject, "gradle");
+		var gradleJavaProject = loadJavaProject(gradleProject, "gradle");
+		Job.getJobManager().join(CorePlugin.GRADLE_JOB_FAMILY, new NullProgressMonitor());
+		return gradleJavaProject;
 	}
 
 	public static IJavaProject loadMavenProjectFromSubFolder(String mavenProject, String subFolder) throws Exception {
@@ -154,7 +158,6 @@ public class BasePropertiesManagerTest {
 		if (!project.exists()) {
 			project.create(description, null);
 			project.open(null);
-
 			// We need to call waitForBackgroundJobs with a Job which does nothing to have a
 			// resolved classpath (IJavaProject#getResolvedClasspath) when search is done.
 			IWorkspaceRunnable runnable = monitor -> monitor.done();

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
@@ -73,7 +73,7 @@ public class MicroProfileFaultTolerancePropertiesTest extends BasePropertiesMana
 
 				// <annotation>/<parameter>
 				p(null, "Bulkhead/value", "int",
-						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, `org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException` occurs."
+						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException occurs."
 								+ System.lineSeparator() + //
 								"" + System.lineSeparator() + //
 								" *  **Returns:**" + System.lineSeparator() + //

--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -24,7 +24,7 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
     <surefire.timeout>600</surefire.timeout>
-    <jdt.ls.version>1.29.0-SNAPSHOT</jdt.ls.version>
+    <jdt.ls.version>1.32.0-SNAPSHOT</jdt.ls.version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-quarkus/issues/638
But Qute-LS will need a similar fix.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
