### PR TITLE
fix: don't generate a symbol name when property starts with '.'

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsProvider.java
@@ -86,7 +86,10 @@ class PropertiesFileSymbolsProvider {
 				String name = getSymbolName(property);
 				if (!StringUtils.isEmpty(name)) {
 					// The property is not an empty line
-					String[] paths = name.split("[.]");
+					// If the property starts with '.', we don't split it to avoid having an empty
+					// name.
+					boolean startsWithDot = name.charAt(0) == '.';
+					String[] paths = startsWithDot ? name.split("[.]", 1) : name.split("[.]");
 					DocumentSymbol symbol = null;
 					for (String path : paths) {
 						symbol = getSymbol(path, property, symbol != null ? symbol.getChildren() : symbols);

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsTest.java
@@ -107,9 +107,24 @@ public class PropertiesFileSymbolsTest {
 	@Test
 	public void justPeriod() throws BadLocationException {
 		String value = ".";
-		testDocumentSymbolsFor(value);
+		testDocumentSymbolsFor(value, ds(".", SymbolKind.Property, r(0, 0, 1), null));
 	}
 
+	@Test
+	public void propertiesWhichStartWithPeriod() throws BadLocationException {
+		String value = ".quarkus\n" + //
+				"  .quarkus2\n" + //
+				"quarkus.\n" + //
+				".mp\n" + //
+				"  .mp2\n";
+		testDocumentSymbolsFor(value, //
+				ds(".quarkus", SymbolKind.Property, r(0, 0, 8), null), //
+				ds(".quarkus2", SymbolKind.Property, r(1, 2, 11), null), //
+				ds("quarkus", SymbolKind.Property, r(2, 0, 8), null), //
+				ds(".mp", SymbolKind.Property, r(3, 0, 3), null), //
+				ds(".mp2", SymbolKind.Property, r(4, 2, 6), null));
+	}
+	
 	@Test
 	public void justEquals() throws BadLocationException {
 		String value = "=";


### PR DESCRIPTION
fix: don't generate a symbol name when property starts with '.'

Fixes https://github.com/redhat-developer/vscode-quarkus/issues/640