### PR TITLE
Fix tests

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/BasePropertiesManagerTest.java
@@ -17,7 +17,9 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,6 +42,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4mp.commons.ClasspathKind;
 import org.eclipse.lsp4mp.commons.DocumentFormat;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
@@ -107,6 +111,7 @@ public class BasePropertiesManagerTest {
 	public static void setUp() {
 		oldLevel = LOGGER.getLevel();
 		LOGGER.setLevel(Level.INFO);
+		enableClassFileContentsSupport();
 	}
 
 	@AfterClass
@@ -275,5 +280,12 @@ public class BasePropertiesManagerTest {
 		IPath output = javaProject.getOutputLocation();
 		IPath filePath = output.append(configFileName);
 		return ResourcesPlugin.getWorkspace().getRoot().getFile(filePath);
+	}
+
+	private static void enableClassFileContentsSupport() {
+		Map<String, Object> extendedClientCapabilities = new HashMap<>();
+		extendedClientCapabilities.put("classFileContentsSupport", "true");
+		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(new ClientCapabilities(),
+				extendedClientCapabilities);
 	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/GenerateAllPropertiesAndDefinition.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/GenerateAllPropertiesAndDefinition.java
@@ -185,9 +185,6 @@ public class GenerateAllPropertiesAndDefinition extends BasePropertiesManagerTes
 			LOGGER.info("Start generating all-quarkus-definitions.json");
 			// Generate all-quarkus-definitions.json
 
-			// Enable classFileContentsSupport to generate jdt Location
-			enableClassFileContentsSupport();
-
 			long definitionsCount = info.getProperties().size()
 					+ info.getHints().stream().map(hint -> hint.getValues().size()).count();
 			List<PropertyDefinition> definitions = new ArrayList<>();
@@ -248,10 +245,4 @@ public class GenerateAllPropertiesAndDefinition extends BasePropertiesManagerTes
 		return definition;
 	}
 
-	private static void enableClassFileContentsSupport() {
-		Map<String, Object> extendedClientCapabilities = new HashMap<>();
-		extendedClientCapabilities.put("classFileContentsSupport", "true");
-		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(new ClientCapabilities(),
-				extendedClientCapabilities);
-	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerLocationTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerLocationTest.java
@@ -13,15 +13,9 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest.MicroProfileMavenProjectName;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -35,9 +29,6 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 
 	@Test
 	public void usingVertxTest() throws Exception {
-		// Enable classFileContentsSupport to generate jdt Location
-		enableClassFileContentsSupport();
-
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.using_vertx);
 
 		// Test with Java sources
@@ -49,9 +40,6 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 
 	@Test
 	public void configPropertiesTest() throws Exception {
-		// Enable classFileContentsSupport to generate jdt Location
-		enableClassFileContentsSupport();
-
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_properties);
 
 		// Test with method
@@ -65,9 +53,6 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 
 	@Test
 	public void configPropertiesMethodTest() throws Exception {
-		// Enable classFileContentsSupport to generate jdt Location
-		enableClassFileContentsSupport();
-
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
 
 		// Test with method with parameters
@@ -81,9 +66,6 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 
 	@Test
 	public void configPropertiesConstructorTest() throws Exception {
-		// Enable classFileContentsSupport to generate jdt Location
-		enableClassFileContentsSupport();
-
 		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
 
 		// Test with constructor with parameters
@@ -119,13 +101,6 @@ public class PropertiesManagerLocationTest extends BasePropertiesManagerTest {
 		Location location = PropertiesManager.getInstance().findPropertyLocation(javaProject, "org.acme.vertx.Fruit",
 				"Banana", null, JDT_UTILS, new NullProgressMonitor());
 		Assert.assertNull(location);
-	}
-
-	private static void enableClassFileContentsSupport() {
-		Map<String, Object> extendedClientCapabilities = new HashMap<>();
-		extendedClientCapabilities.put("classFileContentsSupport", "true");
-		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(new ClientCapabilities(),
-				extendedClientCapabilities);
 	}
 
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
@@ -73,7 +73,7 @@ public class MicroProfileFaultTolerancePropertiesTest extends BasePropertiesMana
 
 				// <annotation>/<parameter>
 				p(null, "Bulkhead/value", "int",
-						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, [org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException](jdt://contents/microprofile-fault-tolerance-api-2.0.3.jar/org.eclipse.microprofile.faulttolerance.exceptions/FaultToleranceDefinitionException.class?=microprofile-fault-tolerance/%5C/home%5C/jenkins%5C/.m2%5C/repository%5C/org%5C/eclipse%5C/microprofile%5C/fault-tolerance%5C/microprofile-fault-tolerance-api%5C/2.0.3%5C/microprofile-fault-tolerance-api-2.0.3.jar=/maven.pomderived=/true=/=/maven.groupId=/org.eclipse.microprofile.fault-tolerance=/=/maven.artifactId=/microprofile-fault-tolerance-api=/=/maven.version=/2.0.3=/=/maven.scope=/compile=/=/maven.pomderived=/true=/%3Corg.eclipse.microprofile.faulttolerance.exceptions%28FaultToleranceDefinitionException.class#28) occurs."
+						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException occurs."
 								+ System.lineSeparator() + //
 								"" + System.lineSeparator() + //
 								" *  **Returns:**" + System.lineSeparator() + //

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/faulttolerance/properties/MicroProfileFaultTolerancePropertiesTest.java
@@ -73,7 +73,7 @@ public class MicroProfileFaultTolerancePropertiesTest extends BasePropertiesMana
 
 				// <annotation>/<parameter>
 				p(null, "Bulkhead/value", "int",
-						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException occurs."
+						"Specify the maximum number of concurrent calls to an instance. The value must be greater than 0. Otherwise, [org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException](jdt://contents/microprofile-fault-tolerance-api-2.0.3.jar/org.eclipse.microprofile.faulttolerance.exceptions/FaultToleranceDefinitionException.class?=microprofile-fault-tolerance/%5C/home%5C/jenkins%5C/.m2%5C/repository%5C/org%5C/eclipse%5C/microprofile%5C/fault-tolerance%5C/microprofile-fault-tolerance-api%5C/2.0.3%5C/microprofile-fault-tolerance-api-2.0.3.jar=/maven.pomderived=/true=/=/maven.groupId=/org.eclipse.microprofile.fault-tolerance=/=/maven.artifactId=/microprofile-fault-tolerance-api=/=/maven.version=/2.0.3=/=/maven.scope=/compile=/=/maven.pomderived=/true=/%3Corg.eclipse.microprofile.faulttolerance.exceptions%28FaultToleranceDefinitionException.class#28) occurs."
 								+ System.lineSeparator() + //
 								"" + System.lineSeparator() + //
 								" *  **Returns:**" + System.lineSeparator() + //

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDiagnosticsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDiagnosticsTest.java
@@ -731,9 +731,16 @@ public class PropertiesFileDiagnosticsTest {
 				d(0, 35, 36, "Unclosed character class near index 0" + ls + "[" + ls + "^" + ls + "",
 						DiagnosticSeverity.Error, ValidationType.value));
 
+		StringBuilder trailingBackslash = new StringBuilder();
+		if (JavaVersion.CURRENT > 17) {
+			trailingBackslash.append("Unescaped trailing backslash");
+		} else {
+			trailingBackslash.append("Unexpected internal error");
+		}
+		trailingBackslash.append(" near index 1");
 		value = "mp.opentracing.server.skip-pattern=\\";
 		testDiagnosticsFor(value, projectInfo, settings, //
-				d(0, 35, 36, "Unescaped trailing backslash near index 1" + ls + "\\" + ls + "", DiagnosticSeverity.Error,
+				d(0, 35, 36, trailingBackslash.toString() + ls + "\\" + ls + "", DiagnosticSeverity.Error,
 						ValidationType.value));
 
 		value = "mp.opentracing.server.skip-pattern={";

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDiagnosticsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileDiagnosticsTest.java
@@ -733,7 +733,7 @@ public class PropertiesFileDiagnosticsTest {
 
 		value = "mp.opentracing.server.skip-pattern=\\";
 		testDiagnosticsFor(value, projectInfo, settings, //
-				d(0, 35, 36, "Unexpected internal error near index 1" + ls + "\\" + ls + "", DiagnosticSeverity.Error,
+				d(0, 35, 36, "Unescaped trailing backslash near index 1" + ls + "\\" + ls + "", DiagnosticSeverity.Error,
 						ValidationType.value));
 
 		value = "mp.opentracing.server.skip-pattern={";


### PR DESCRIPTION
- It appears whatever was happening in the Bulkhead documentation has now been reverted
- Seems like the ~~parser error message~~ *regex parser error message* has changed *in a newer Java version* but one of the tests still uses the old message

Signed-off-by: David Thompson <davthomp@redhat.com>
