### PR TITLE
fix : prevent from empty name symbol

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsProvider.java
@@ -88,10 +88,8 @@ class PropertiesFileSymbolsProvider {
 					// The property is not an empty line
 					// If the property starts with '.', we don't split it to avoid having an empty
 					// name.
-					boolean startsWithDot = name.charAt(0) == '.';
-					String[] paths = startsWithDot ? name.split("[.]", 1) : name.split("[.]");
 					DocumentSymbol symbol = null;
-					for (String path : paths) {
+					for (String path : getPaths(name)) {
 						symbol = getSymbol(path, property, symbol != null ? symbol.getChildren() : symbols);
 					}
 					if (symbol != null) {
@@ -105,6 +103,30 @@ class PropertiesFileSymbolsProvider {
 			}
 		}
 		return symbols;
+	}
+
+	private List<String> getPaths(String name) {
+		List<String> paths = new ArrayList<>();
+		StringBuilder path = new StringBuilder();
+		Character previous = null;
+		for (int i = 0; i < name.length(); i++) {
+			char c = name.charAt(i);
+			if (c == '.') {
+				if (previous == null || (previous == '.' && path.length() == 0)) {
+					path.append(c);
+				} else {
+					paths.add(path.length() > 0 ? path.toString() : ".");
+					path.setLength(0);
+				}
+			} else {
+				path.append(c);
+			}
+			previous = c;
+		}
+		if (path.length() > 0) {
+			paths.add(path.toString());
+		}
+		return paths;
 	}
 
 	private static DocumentSymbol getSymbol(String path, Property property, List<DocumentSymbol> children) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileSymbolsTest.java
@@ -100,8 +100,7 @@ public class PropertiesFileSymbolsTest {
 				"application \\\n" + //
 				"name";
 		testSymbolInformationsFor(value, //
-				s("quarkus.application.name", SymbolKind.Property, "microprofile-config.properties", r(0, 0, 3, 4))
-		);
+				s("quarkus.application.name", SymbolKind.Property, "microprofile-config.properties", r(0, 0, 3, 4)));
 	};
 
 	@Test
@@ -110,6 +109,37 @@ public class PropertiesFileSymbolsTest {
 		testDocumentSymbolsFor(value, ds(".", SymbolKind.Property, r(0, 0, 1), null));
 	}
 
+	@Test
+	public void twoPeriods() throws BadLocationException {
+		String value = "a..b";
+		testDocumentSymbolsFor(value, //
+				ds("a", SymbolKind.Package, r(0, 0, 4), null, //
+						Arrays.asList( //
+								ds(".b", SymbolKind.Property, r(0, 0, 4), null))));
+	}
+
+	@Test
+	public void threePeriods() throws BadLocationException {
+		String value = "a...b";
+		testDocumentSymbolsFor(value, //
+				ds("a", SymbolKind.Package, r(0, 0, 5), null, //
+						Arrays.asList( //
+								ds(".", SymbolKind.Package, r(0, 0, 5), null, //
+										Arrays.asList( //
+												ds("b", SymbolKind.Property, r(0, 0, 5), null))))));
+	}
+	
+	@Test
+	public void fourPeriods() throws BadLocationException {
+		String value = "a....b";
+		testDocumentSymbolsFor(value, //
+				ds("a", SymbolKind.Package, r(0, 0, 6), null, //
+						Arrays.asList( //
+								ds(".", SymbolKind.Package, r(0, 0, 6), null, //
+										Arrays.asList( //
+												ds(".b", SymbolKind.Property, r(0, 0, 6), null))))));
+	}
+	
 	@Test
 	public void propertiesWhichStartWithPeriod() throws BadLocationException {
 		String value = ".quarkus\n" + //
@@ -124,7 +154,7 @@ public class PropertiesFileSymbolsTest {
 				ds(".mp", SymbolKind.Property, r(3, 0, 3), null), //
 				ds(".mp2", SymbolKind.Property, r(4, 2, 6), null));
 	}
-	
+
 	@Test
 	public void justEquals() throws BadLocationException {
 		String value = "=";


### PR DESCRIPTION
fix : prevent from empty name symbol

Given this microprofile-config.properties file which have 2 dots in property:

`a..b=`

vscode crashes because symbol name must be never empty.

This PR prevent from non empty name symbol.