### PR TITLE
fix: split register completion options for Java / Properties

### DIFF
--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/MicroProfileLanguageIds.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/MicroProfileLanguageIds.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4mp;
+
+/**
+ * MicroProfile language ids.
+ */
+public class MicroProfileLanguageIds {
+
+	public static final String MICROPROFILE_PROPERTIES = "microprofile-properties";
+
+	public static final String JAVA = "java";
+
+	private MicroProfileLanguageIds() {
+	}
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesConstants.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesConstants.java
@@ -42,7 +42,9 @@ public class ServerCapabilitiesConstants {
 
 	public static final String WORKSPACE_SYMBOLS = "workspace/symbol";
 
-	public static final String COMPLETION_ID = UUID.randomUUID().toString();
+	public static final String COMPLETION_ID_FOR_PROPERTIES = UUID.randomUUID().toString();
+	public static final String COMPLETION_ID_FOR_JAVA = UUID.randomUUID().toString();
+
 	public static final String HOVER_ID = UUID.randomUUID().toString();
 	public static final String DOCUMENT_SYMBOL_ID = UUID.randomUUID().toString();
 	public static final String DEFINITION_ID = UUID.randomUUID().toString();

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesInitializer.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/settings/capabilities/ServerCapabilitiesInitializer.java
@@ -13,8 +13,8 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.settings.capabilities;
 
-import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_CODELENS_OPTIONS;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_CODEACTION_OPTIONS;
+import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_CODELENS_OPTIONS;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_COMPLETION_OPTIONS;
 
 import org.eclipse.lsp4j.ServerCapabilities;

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilitiesTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/settings/capabilities/MicroProfileCapabilitiesTest.java
@@ -9,7 +9,8 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.settings.capabilities;
 
-import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.COMPLETION_ID;
+import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.COMPLETION_ID_FOR_JAVA;
+import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.COMPLETION_ID_FOR_PROPERTIES;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.DEFAULT_COMPLETION_OPTIONS;
 import static org.eclipse.lsp4mp.settings.capabilities.ServerCapabilitiesConstants.HOVER_ID;
 import static org.junit.Assert.assertEquals;
@@ -58,8 +59,9 @@ public class MicroProfileCapabilitiesTest {
 		setAllCapabilities(true);
 		setAndInitializeCapabilities();
 
-		assertEquals(2, capabilityIDs.size());
-		assertEquals(true, capabilityIDs.contains(COMPLETION_ID));
+		assertEquals(3, capabilityIDs.size());
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID_FOR_PROPERTIES));
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID_FOR_JAVA));
 		assertEquals(true, capabilityIDs.contains(HOVER_ID));
 
 		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
@@ -96,8 +98,9 @@ public class MicroProfileCapabilitiesTest {
 
 		setAndInitializeCapabilities();
 
-		assertEquals(1, capabilityIDs.size());
-		assertEquals(true, capabilityIDs.contains(COMPLETION_ID));
+		assertEquals(2, capabilityIDs.size());
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID_FOR_PROPERTIES));
+		assertEquals(true, capabilityIDs.contains(COMPLETION_ID_FOR_JAVA));
 		assertEquals(false, capabilityIDs.contains(HOVER_ID));
 
 		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer


### PR DESCRIPTION
fix: split register completion options for Java / Properties

This PR allows to register options with given languageId 

1. to avoid sending LSP request in Java file:

 * for InlayHint
 * for documentSymbol
 * for formatting / rangeFormatting (already done)
 * for documentHighlight (already done)

2. customize completion trigger characters and resolveCompletion between microprofile-config.properties and Java files

For instance when you write `{` in Java file it should not trigger completion (today you can see that it triggers completion in Java file when you type `{`

It is not annoying for vscode but very annoying for IJ (see issue at https://github.com/redhat-developer/intellij-quarkus/issues/1395)

As we did some languageId filter with `microprofile-properties` languageId , we need to add in the filter documentSelector the `quarkus-properties` languageId to avoid loosing features like inlay hint, dpcument symbol. The PR https://github.com/redhat-developer/quarkus-ls/pull/999 covers that.

There is a bug in application.properties which doesnt manage highlight when you click on properties. I have fixed this bug too in https://github.com/redhat-developer/quarkus-ls/pull/999