### PR TITLE
Improve the Target platform for JDT Extension components.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/open-liberty/.project
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/projects/maven/open-liberty/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>app-name</name>
+	<name>open-liberty</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/ProjectLabelTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/ProjectLabelTest.java
@@ -67,49 +67,56 @@ public class ProjectLabelTest {
 
 	@Test
 	public void getProjectLabelMultipleProjects() throws Exception {
-		IJavaProject quarkusMaven = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.using_vertx);
-		IJavaProject quarkusGradle = BasePropertiesManagerTest
-				.loadGradleProject(GradleProjectName.quarkus_gradle_project);
-		IJavaProject maven = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.empty_maven_project);
-		IJavaProject gradle = BasePropertiesManagerTest.loadGradleProject(GradleProjectName.empty_gradle_project);
+		IJavaProject [] projects = BasePropertiesManagerTest.loadJavaProjects(new String [] {
+				"maven/" + MicroProfileMavenProjectName.using_vertx,
+				"gradle/" + GradleProjectName.quarkus_gradle_project,
+				"maven/" + MicroProfileMavenProjectName.empty_maven_project,
+				"gradle/" + GradleProjectName.empty_gradle_project
+				});
 		List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo();
 
-		assertProjectLabelInfoContainsProject(projectLabelEntries, quarkusMaven, quarkusGradle, maven, gradle);
-		assertLabels(projectLabelEntries, quarkusMaven, "microprofile", "maven");
-		assertLabels(projectLabelEntries, quarkusGradle, "microprofile", "gradle");
-		assertLabels(projectLabelEntries, maven, "maven");
-		assertLabels(projectLabelEntries, gradle, "gradle");
+		assertProjectLabelInfoContainsProject(projectLabelEntries, projects[0], projects[1], projects[2], projects[3]);
+		assertLabels(projectLabelEntries, projects[0], "microprofile", "maven");
+		assertLabels(projectLabelEntries, projects[1], "microprofile", "gradle");
+		assertLabels(projectLabelEntries, projects[2], "maven");
+		assertLabels(projectLabelEntries, projects[3], "gradle");
 	}
 
 	@Test
 	public void projectNameMaven() throws Exception {
-		IJavaProject quarkusMaven = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.using_vertx);
-		IJavaProject maven = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.empty_maven_project);
-		IJavaProject folderNameDifferent = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.folder_name_different_maven);
+		IJavaProject[] projects = BasePropertiesManagerTest.loadJavaProjects(new String [] {
+				"maven/" + MicroProfileMavenProjectName.using_vertx,
+				"maven/" + MicroProfileMavenProjectName.empty_maven_project,
+				"maven/" + MicroProfileMavenProjectName.folder_name_different_maven
+		});
 		List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo();
-		assertName(projectLabelEntries, quarkusMaven, "using-vertx");
-		assertName(projectLabelEntries, maven, "empty-maven-project");
-		assertName(projectLabelEntries, folderNameDifferent, "mostly.empty");
+		assertName(projectLabelEntries, projects[0], "using-vertx");
+		assertName(projectLabelEntries, projects[1], "empty-maven-project");
+		assertName(projectLabelEntries, projects[2], "mostly.empty");
 	}
 
 	@Test
 	public void projectNameSameFolderName() throws Exception {
-		IJavaProject empty1 = BasePropertiesManagerTest.loadMavenProject(MicroProfileMavenProjectName.empty_maven_project);
-		IJavaProject empty2 = BasePropertiesManagerTest.loadMavenProjectFromSubFolder(MicroProfileMavenProjectName.other_empty_maven_project, "folder");
+		IJavaProject [] empties = BasePropertiesManagerTest.loadJavaProjects(new String [] {
+				"maven/" + MicroProfileMavenProjectName.empty_maven_project,
+				"maven/" + "folder/" + MicroProfileMavenProjectName.other_empty_maven_project});
 		List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo();
-		assertName(projectLabelEntries, empty1, "empty-maven-project");
-		assertName(projectLabelEntries, empty2, "other-empty-maven-project");
+		assertName(projectLabelEntries, empties[0], "empty-maven-project");
+		assertName(projectLabelEntries, empties[1], "other-empty-maven-project");
 	}
 
 	@Test
 	public void projectNameGradle() throws Exception {
-		IJavaProject quarkusGradle = BasePropertiesManagerTest.loadGradleProject(GradleProjectName.quarkus_gradle_project);
-		IJavaProject gradle = BasePropertiesManagerTest.loadGradleProject(GradleProjectName.empty_gradle_project);
-		IJavaProject renamedGradle = BasePropertiesManagerTest.loadGradleProject(GradleProjectName.renamed_quarkus_gradle_project);
+		IJavaProject [] projects = BasePropertiesManagerTest.loadJavaProjects(new String [] {
+				"gradle/" + GradleProjectName.quarkus_gradle_project,
+				"gradle/" + GradleProjectName.empty_gradle_project,
+				"gradle/" + GradleProjectName.renamed_quarkus_gradle_project
+		});
 		List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo();
-		assertName(projectLabelEntries, quarkusGradle, "quarkus-gradle-project");
-		assertName(projectLabelEntries, gradle, "empty-gradle-project");
-		assertName(projectLabelEntries, renamedGradle, "my-gradle-project");
+		assertName(projectLabelEntries, projects[0], "quarkus-gradle-project");
+		assertName(projectLabelEntries, projects[1], "empty-gradle-project");
+		// See https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/1743
+		assertName(projectLabelEntries, projects[2], "my-gradle-project-renamed-gradle");
 	}
 
 	private static void assertProjectLabelInfoContainsProject(List<ProjectLabelInfoEntry> projectLabelEntries,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/snippets/JavaFileCursorContextTest.java
@@ -16,10 +16,13 @@ package org.eclipse.lsp4mp.jdt.core.snippets;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 
+import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
@@ -28,6 +31,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4mp.commons.JavaCursorContextKind;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaCompletionParams;
 import org.eclipse.lsp4mp.jdt.core.BasePropertiesManagerTest;
+import org.eclipse.lsp4mp.jdt.core.JavaUtils;
 import org.eclipse.lsp4mp.jdt.core.PropertiesManagerForJava;
 import org.junit.After;
 import org.junit.Test;
@@ -42,11 +46,10 @@ public class JavaFileCursorContextTest extends BasePropertiesManagerTest {
 
 	@After
 	public void cleanUp() throws Exception {
-		IJavaProject javaProject = loadMavenProject(MicroProfileMavenProjectName.config_hover);
-		IProject project = javaProject.getProject();
-		IFile javaFile = project.getFile(new Path("src/main/java/org/acme/config/Empty.java"));
-		javaFile.refreshLocal(IResource.DEPTH_ZERO, null);
-		javaFile.setContents(new ByteArrayInputStream("".getBytes()), 0, MONITOR);
+		File to = new File(JavaUtils.getWorkingProjectDirectory(),
+				java.nio.file.Paths.get("maven", MicroProfileMavenProjectName.config_hover).toString());
+		FileUtils.forceDelete(to);
+		ResourcesPlugin.getWorkspace().getRoot().getProject(MicroProfileMavenProjectName.config_hover).delete(true, null);
 	}
 
 	// context kind tests

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
@@ -2,7 +2,17 @@
 <?pde version="3.8"?>
 <target name="LSP4MP Target Platform">
 	<locations>
-		<!--<location type="Target" uri="https://raw.githubusercontent.com/eclipse/eclipse.jdt.ls/master/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target"/>-->
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.jdt" version="0.0.0"/>
+            <unit id="org.eclipse.buildship.core" version="0.0.0"/>
+            <unit id="org.apache.commons.commons-io" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest"/>
+        </location>
 		<location includeDependencyDepth="infinite" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 			<dependencies>
 				<dependency>

--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <tycho.version>3.0.5</tycho.version>
+    <tycho.version>4.0.9</tycho.version>
     <tycho.extras.version>${tycho.version}</tycho.extras.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse/lsp4mp</tycho.scmUrl>
     <tycho.generateSourceReferences>true</tycho.generateSourceReferences>
@@ -24,7 +24,6 @@
     <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
     <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
     <surefire.timeout>600</surefire.timeout>
-    <jdt.ls.version>1.40.0-SNAPSHOT</jdt.ls.version>
   </properties>
   <scm>
     <connection>scm:git:git@github.com:eclipse/lsp4mp.git</connection>
@@ -32,17 +31,6 @@
     <url>https://github.com/eclipse/lsp4mp</url>
     <tag>${project.version}</tag>
   </scm>
-  <repositories>
-    <repository>
-      <id>jdt.ls.p2</id>
-      <layout>p2</layout>
-      <url>https://download.eclipse.org/jdtls/snapshots/repository/latest/</url>
-    </repository>
-    <repository>
-      <id>jdt.ls.maven</id>
-      <url>https://repo.eclipse.org/content/repositories/jdtls-snapshots/</url>
-    </repository>
-  </repositories>
   <build>
     <plugins>
       <plugin>
@@ -62,11 +50,6 @@
               <groupId>org.eclipse.lsp4mp</groupId>
               <artifactId>org.eclipse.lsp4mp.jdt.tp</artifactId>
               <version>${project.version}</version>
-            </artifact>
-            <artifact>
-              <groupId>org.eclipse.jdt.ls</groupId>
-              <artifactId>org.eclipse.jdt.ls.tp</artifactId>
-              <version>${jdt.ls.version}</version>
             </artifact>
           </target>
         </configuration>


### PR DESCRIPTION
We can merge this after @angelozerr does the release. We would need to update the platform I-build repo just like JDT-LS does, unless we automate it, or avoid using the I-build location here.

- Use the JDT-LS repository, which now contains all dependencies to build the target platform
- Include o.e.platform.feature.group for the test runtime
- The target file can now be used both for building and development