### PR TITLE
Configure version of tycho-versions-plugin to use

### DIFF
--- a/microprofile.jdt/pom.xml
+++ b/microprofile.jdt/pom.xml
@@ -103,6 +103,11 @@
             <forkedProcessTimeoutInSeconds>${surefire.timeout}</forkedProcessTimeoutInSeconds>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-versions-plugin</artifactId>
+          <version>4.0.8</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Use 4.0.8; there appears to be [a bug](https://github.com/eclipse-tycho/tycho/issues/4381) in 4.0.9 related to missing classes