### PR TITLE
Update target platform to 4.35-I-builds.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
@@ -4,7 +4,7 @@
 	<locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.34-I-builds/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.35-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>


### PR DESCRIPTION
It's usually good to do this on or just prior to Eclipse's GA day, since the previous I-build repo will disappear.