### PR TITLE
Potential fix for `JDTTypeUtils.findType()`

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
@@ -46,7 +46,14 @@ public class JDTTypeUtils {
 
 	public static IType findType(IJavaProject project, String name) {
 		try {
-			return project.findType(name, new NullProgressMonitor());
+			IType type = project.findType(name, new NullProgressMonitor());
+			if (type != null && type.exists()) {
+				return type;
+			}
+		} catch (JavaModelException e) {
+		}
+		try {
+			return project.findType(name);
 		} catch (JavaModelException e) {
 			return null;
 		}


### PR DESCRIPTION
https://github.com/redhat-developer/quarkus-ls/commit/f8561effd6c12024bbfb5f8eaa4b90c0aeb4967d caused some regressions in the quarkus-ls tests, since some types were no longer found by JDTTypeUtils.findType(). This attempts to fix it again.

Try the 'secondary types' search first, and if that fails, fall back to the old search we were doing.