### PR TITLE
Guard against annotation binding failing to resolve.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/AnnotationUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/AnnotationUtils.java
@@ -265,6 +265,9 @@ public class AnnotationUtils {
 	 */
 	public static boolean isMatchAnnotation(Annotation annotation, String annotationName) {
 		IAnnotationBinding binding = annotation.resolveAnnotationBinding();
+		if (binding == null) {
+			return false;
+		}
 		ITypeBinding annotationType = binding.getAnnotationType();
 		if (annotationType == null) {
 			return false;


### PR DESCRIPTION
Wasn't able to reproduce a case of this, but I have seen stacktraces that clearly show :

```
SEVERE: Error while visiting node with org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceASTValidator
java.lang.NullPointerException: Cannot invoke "org.eclipse.jdt.core.dom.IAnnotationBinding.getAnnotationType()" because "binding" is null
    at org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils.isMatchAnnotation(AnnotationUtils.java:268)
    at org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceASTValidator.validateMethod(MicroProfileFaultToleranceASTValidator.java:179)   
    at org.eclipse.lsp4mp.jdt.internal.faulttolerance.java.MicroProfileFaultToleranceASTValidator.visit(MicroProfileFaultToleranceASTValidator.java:123)
    at org.eclipse.lsp4mp.jdt.internal.core.java.validators.MultiASTVisitor.visit(MultiASTVisitor.java:118)
```