### PR TITLE
fix: Optional indexed property

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/metadata/ItemMetadata.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/metadata/ItemMetadata.java
@@ -59,6 +59,8 @@ public class ItemMetadata extends ItemBase {
 	private boolean required;
 	private int phase;
 
+	private transient List<String> wildcardExpansions;
+
 	private List<ConverterKind> converterKinds;
 
 	public String getType() {
@@ -123,6 +125,42 @@ public class ItemMetadata extends ItemBase {
 
 	public void setConverterKinds(List<ConverterKind> converterKinds) {
 		this.converterKinds = converterKinds;
+	}
+
+	/**
+	 * Returns all possible expansions of the property name pattern contained in
+	 * this metadata.
+	 * <p>
+	 * Each block delimited by curly braces "{...}" or square brackets "[...]" is
+	 * treated as a wildcard. For example, a pattern like
+	 * "quarkus.log.category.{*}.level" could produce variants such as:
+	 * <ul>
+	 * <li>"quarkus.log.category.{*}.level"</li>
+	 * <li>"quarkus.log.category.level"</li>
+	 * </ul>
+	 * This allows matching property names with or without specific segments,
+	 * handling multiple wildcards and combinations efficiently.
+	 *
+	 * @return a list of all expanded property name variants, or {@code null} if not
+	 *         computed yet
+	 */
+	public List<String> getWildcardExpansions() {
+		return wildcardExpansions;
+	}
+
+	/**
+	 * Sets the cached expansions for the property name pattern contained in this
+	 * metadata.
+	 * <p>
+	 * This should be used to store the results of {@link #expandPatterns(String)}
+	 * or similar logic that generates all combinations of wildcards in the pattern.
+	 * Caching the expansions avoids recomputing them multiple times for the same
+	 * metadata.
+	 *
+	 * @param expansions the list of expanded property name variants to cache
+	 */
+	public void setWildcardExpansions(List<String> expansions) {
+		this.wildcardExpansions = expansions;
 	}
 
 	public boolean isStringType() {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/metadata/ItemMetadata.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/metadata/ItemMetadata.java
@@ -59,6 +59,8 @@ public class ItemMetadata extends ItemBase {
 	private boolean required;
 	private int phase;
 
+	private transient List<String> wildcardExpansions;
+
 	private List<ConverterKind> converterKinds;
 
 	public String getType() {
@@ -123,6 +125,42 @@ public class ItemMetadata extends ItemBase {
 
 	public void setConverterKinds(List<ConverterKind> converterKinds) {
 		this.converterKinds = converterKinds;
+	}
+
+	/**
+	 * Returns all possible expansions of the property name pattern contained in
+	 * this metadata.
+	 * <p>
+	 * Each block delimited by curly braces "{...}" or square brackets "[...]" is
+	 * treated as a wildcard. For example, a pattern like
+	 * "quarkus.log.category.{*}.level" could produce variants such as:
+	 * <ul>
+	 * <li>"quarkus.log.category.{*}.level"</li>
+	 * <li>"quarkus.log.category.level"</li>
+	 * </ul>
+	 * This allows matching property names with or without specific segments,
+	 * handling multiple wildcards and combinations efficiently.
+	 *
+	 * @return a list of all expanded property name variants, or {@code null} if not
+	 *         computed yet
+	 */
+	public List<String> getWildcardExpansions() {
+		return wildcardExpansions;
+	}
+
+	/**
+	 * Sets the cached expansions for the property name pattern contained in this
+	 * metadata.
+	 * <p>
+	 * This should be used to store the results of {@link #expandPatterns(String)}
+	 * or similar logic that generates all combinations of wildcards in the pattern.
+	 * Caching the expansions avoids recomputing them multiple times for the same
+	 * metadata.
+	 *
+	 * @param expansions the list of expanded property name variants to cache
+	 */
+	public void setWildcardExpansions(List<String> expansions) {
+		this.wildcardExpansions = expansions;
 	}
 
 	public boolean isStringType() {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/MicroProfileProjectInfoTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/MicroProfileProjectInfoTest.java
@@ -73,27 +73,41 @@ public class MicroProfileProjectInfoTest {
 	}
 
 	@Test
-	public void getPropertyMapWithOneKey() {
+	public void getPropertyMapWithOneKey_valueQuotted() {
 		MicroProfileProjectInfo info = getDefaultMicroProfileProjectInfo();
 		PropertyInfo property = getProperty("quarkus.log.category.\"com.lordofthejars\".level", info);
-
-		assertNotNull(property);
-		assertNotNull(property.getProperty());
-		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
-
-		property = getProperty("quarkus.log.category.com.level", info);
-
-		assertNotNull(property);
-		assertNotNull(property.getProperty());
-		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
-
-		property = getProperty("quarkus.log.category.com\\\\.lordofthejars.level", info);
-
 		assertNotNull(property);
 		assertNotNull(property.getProperty());
 		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
 	}
 
+	@Test
+	public void getPropertyMapWithOneKey_valueSimple() {
+		MicroProfileProjectInfo info = getDefaultMicroProfileProjectInfo();
+		PropertyInfo property = getProperty("quarkus.log.category.com.level", info);
+		assertNotNull(property);
+		assertNotNull(property.getProperty());
+		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
+	}
+
+	@Test
+	public void getPropertyMapWithOneKey_valueAntiSlash() {
+		MicroProfileProjectInfo info = getDefaultMicroProfileProjectInfo();
+		PropertyInfo property = getProperty("quarkus.log.category.com\\\\.lordofthejars.level", info);
+		assertNotNull(property);
+		assertNotNull(property.getProperty());
+		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
+	}
+
+	@Test
+	public void getPropertyMapWithOneKey_valueNone() {
+		MicroProfileProjectInfo info = getDefaultMicroProfileProjectInfo();
+		PropertyInfo property = getProperty("quarkus.log.category.level", info);
+		assertNotNull(property);
+		assertNotNull(property.getProperty());
+		assertEquals("quarkus.log.category.{*}.level", property.getProperty().getName());
+	}
+	
 	@Test
 	@Ignore("Ignore this test since quarkus.keycloak.policy-enforcer.claim-information-point.{*}.{*}.{*} no longer exists")
 	public void getPropertyMapWithThreeKeys() {


### PR DESCRIPTION
fix: Optional indexed property

This PR allows to write optional key or index in a property which have Map or List.

For instance `quarkus.log.category.{*}.level` defines a Map of level. With is PR you can define the property without key (ex: `quarkus.log.category."foo".level`) like:

`quarkus.log.category.level=ERROR`