### PR TITLE
Support for value validation with Enum in Safe mode

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/DiagnosticsCollector.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/DiagnosticsCollector.java
@@ -11,7 +11,9 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.lsp4mp.commons.runtime.converter;
+package org.eclipse.lsp4mp.commons.runtime;
+
+import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
 
 /**
  * Functional interface used to collect diagnostics produced during the

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/EnumConstantsProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/EnumConstantsProvider.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides the list of constant names for a given enum type.
+ *
+ * <p>
+ * This functional interface is used by the MicroProfile runtime support to 
+ * resolve the allowed values of an enum when validating property values.
+ * </p>
+ *
+ * <p>
+ * The behavior depends on the execution mode:
+ * </p>
+ * <ul>
+ *   <li><b>FULL mode</b>: Implementations may attempt to load the enum class 
+ *       from the project classpath and return its declared constants.</li>
+ *   <li><b>SAFE mode</b>: Implementations cannot access project classes. In 
+ *       this case, constants may be resolved from fallback mechanisms 
+ *       (e.g., SmallRye Config hosted in the Language Server) or may return 
+ *       an empty list if the enum type is unknown.</li>
+ * </ul>
+ *
+ * <p>
+ * Returning an empty list never causes a failure by itself: it simply means 
+ * the validator cannot offer enum-aware validation for that type.
+ * </p>
+ */
+@FunctionalInterface
+public interface EnumConstantsProvider {
+
+	public static class SimpleEnumConstantsProvider implements EnumConstantsProvider {
+
+		private Map<String, List<String>> enums;
+		
+		@Override
+		public List<String> getConstants(String enumType) {
+			return enums != null ? enums.get(enumType) : null;
+		}
+		
+		public void addEnumConstants(String enumType, List<String> enumConstNames) {
+			if (enums == null) {
+				enums = new HashMap<>();
+			}
+			enums.put(enumType, enumConstNames);
+		}		
+	}
+	
+    /**
+     * Returns the list of constant names for the given enum type.
+     *
+     * @param enumType the fully qualified name of the enum class
+     * @return the list of enum constant names, or an empty list if the enum cannot be resolved
+     */
+    List<String> getConstants(String enumType);
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/TypeProvider.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/TypeProvider.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime;
+
+import java.lang.reflect.Type;
+
+/**
+ * Resolves a type from its fully qualified name, optionally using an
+ * {@link EnumConstantsProvider} when the target type is an enum.
+ *
+ * <p>
+ * This interface abstracts the mechanism used by the MicroProfile runtime
+ * support and configuration validator to resolve Java types referenced in
+ * configuration metadata. The resolution strategy depends on the
+ * {@link ExecutionMode}:
+ * </p>
+ *
+ * <ul>
+ *   <li><b>FULL mode</b>: The implementation may load classes from the
+ *       project classpath (for example using the project's class loader).
+ *       Custom enums, library enums and other project types can be resolved.</li>
+ *
+ *   <li><b>SAFE mode</b>: The project classpath is not used. No reflection
+ *       is allowed. Implementations must avoid loading project classes.
+ *       Types may be resolved only through known built-in types or metadata
+ *       provided by the Language Server (e.g. SmallRye Config hosted by the LS).
+ *       Custom project types generally cannot be resolved.</li>
+ * </ul>
+ *
+ * <p>
+ * When the given type represents an enum and cannot be loaded (e.g. in SAFE
+ * mode or if the type is unknown), the provided
+ * {@link EnumConstantsProvider} may be consulted as a fallback to retrieve
+ * the list of allowed enum constants, enabling partial validation even
+ * without runtime class loading.
+ * </p>
+ *
+ * <p>
+ * If the type cannot be resolved, implementations may return {@code null}.
+ * Validation logic should treat a {@code null} type as "unknown type".
+ * </p>
+ */
+public interface TypeProvider {
+
+    /**
+     * Resolves the Java {@link Type} corresponding to the given fully
+     * qualified type name.
+     *
+     * @param type the fully qualified name of the target type
+     * @param enumConstNamesProvider provider used to retrieve enum constants
+     *        when the type represents an enum but cannot be loaded
+     * @param executionMode determines whether project classpath and reflection
+     *        are allowed ({@code FULL}) or forbidden ({@code SAFE})
+     * @return the resolved {@link Type}, or {@code null} if it cannot be resolved
+     */
+    Type findType(String type,
+                       EnumConstantsProvider enumConstNamesProvider,
+                       ExecutionMode executionMode);
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/AbstractConverterValidator.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/AbstractConverterValidator.java
@@ -17,6 +17,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+
 /**
  * Base class for implementing a MicroProfile Config value validator with
  * conversion support.
@@ -49,7 +51,7 @@ public abstract class AbstractConverterValidator<T> implements ConverterValidato
 	private final T config;
 
 	/** The target type for conversion */
-	private final Class<?> forType;
+	private Class<?> forType;
 
 	/** Indicates whether the validator has been prepared */
 	private boolean prepared;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterRuntimeSupportApi.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterRuntimeSupportApi.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
 import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
 import org.eclipse.lsp4mp.commons.runtime.MicroProfileRuntimeSupport;
 
@@ -91,9 +93,12 @@ public interface ConverterRuntimeSupportApi extends MicroProfileRuntimeSupport {
 	 * </li>
 	 * </ul>
 	 *
-	 * @param value     the raw configuration value to validate
-	 * @param type      the fully-qualified type name expected
-	 * @param collector the diagnostics collector used to report validation errors
+	 * @param value          the raw configuration value to validate
+	 * @param type           the fully-qualified type name expected
+	 * @param enumConstNames
+	 * @param collector      the diagnostics collector used to report validation
+	 *                       errors
 	 */
-	void validate(String value, String type, DiagnosticsCollector collector);
+	void validate(String value, String type, EnumConstantsProvider enumConstNamesProvider,
+			DiagnosticsCollector collector);
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterValidator.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterValidator.java
@@ -13,6 +13,11 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
+
 /**
  * Represents a validator that can check a string value against a specific type
  * using the project's MicroProfile Config converters.
@@ -25,29 +30,34 @@ package org.eclipse.lsp4mp.commons.runtime.converter;
  */
 public interface ConverterValidator {
 
-    /**
-     * Validates the given value and collects diagnostics if the value is invalid.
-     *
-     * @param value     the string value to validate
-     * @param start     the start offset in the source (for diagnostics)
-     * @param collector collector used to report validation errors
-     */
-    void validate(String value, int start, DiagnosticsCollector collector);
+	/**
+	 * Validates the given value and collects diagnostics if the value is invalid.
+	 *
+	 * @param value     the string value to validate
+	 * @param start     the start offset in the source (for diagnostics)
+	 * @param collector collector used to report validation errors
+	 */
+	void validate(String value, int start, DiagnosticsCollector collector);
 
-    /**
-     * Validates the given value assuming start offset 0.
-     *
-     * @param value     the string value to validate
-     * @param collector collector used to report validation errors
-     */
-    default void validate(String value, DiagnosticsCollector collector) {
-        validate(value, 0, collector);
-    }
+	/**
+	 * Validates the given value assuming start offset 0.
+	 *
+	 * @param value     the string value to validate
+	 * @param collector collector used to report validation errors
+	 */
+	default void validate(String value, DiagnosticsCollector collector) {
+		validate(value, 0, collector);
+	}
 
-    /**
-     * Indicates whether this validator is ready to perform validation.
-     *
-     * @return true if the validator can validate values for its type, false otherwise
-     */
-    boolean canValidate();
+	default void refreshEnumType(EnumConstantsProvider enumConstNamesProvider, TypeProvider typeProvider, ExecutionMode executionMode) {
+		// Do nothing
+	}
+	
+	/**
+	 * Indicates whether this validator is ready to perform validation.
+	 *
+	 * @return true if the validator can validate values for its type, false
+	 *         otherwise
+	 */
+	boolean canValidate();
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/full/FullConverterValidator.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/full/FullConverterValidator.java
@@ -16,6 +16,9 @@ package org.eclipse.lsp4mp.commons.runtime.converter.full;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
 import org.eclipse.lsp4mp.commons.runtime.converter.AbstractConverterValidator;
 import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
 
@@ -133,5 +136,20 @@ class FullConverterValidator extends AbstractConverterValidator<Object> {
 		this.getConverterMethod = getConverter;
 		this.convertMethod = convert;
 		return true;
+	}
+
+	@Override
+	public void refreshEnumType(EnumConstantsProvider enumConstNamesProvider, TypeProvider typeProvider,
+			ExecutionMode executionMode) {
+		Class<?> forType = getForType();
+		if (forType != null && forType.isEnum()) {
+			forType = (Class<?>) typeProvider.findType(forType.getTypeName(), enumConstNamesProvider,
+					executionMode);
+			try {
+				initialize();
+			} catch (Exception e) {
+				// Do nothing
+			}
+		}
 	}
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/EnumTypeConverterValidator.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/EnumTypeConverterValidator.java
@@ -1,0 +1,169 @@
+/******************************************************************************
+ *  EnumTypeConverterValidator
+ *  ---------------------------------------------------------------------------
+ *  This file is part of the MicroProfile / SmallRye configuration validation
+ *  system (safe runtime conversion).
+ *
+ *  It validates that a given string value corresponds to an existing enum
+ *  constant, using the hyphenated convention (e.g. "MY_VALUE" → "my-value").
+ *
+ *  Original code preserved; only documentation and file header added.
+ ******************************************************************************/
+
+package org.eclipse.lsp4mp.commons.runtime.converter.safe;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
+import org.eclipse.lsp4mp.commons.runtime.TypeSignatureParser.EnumType;
+import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
+
+import io.smallrye.config.common.utils.StringUtil;
+
+/**
+ * A {@link ConverterValidator} implementation dedicated to validating that a
+ * user-provided string corresponds to a valid enumeration constant.
+ * <p>
+ * This validator:
+ * <ul>
+ *   <li>Normalizes input values using the hyphenation convention
+ *       (via {@code StringUtil.skewer()}).</li>
+ *   <li>Supports dynamic refresh of enum constants through
+ *       {@link EnumConstantsProvider}.</li>
+ *   <li>Reports diagnostics when the provided value does not match any known
+ *       enum constant.</li>
+ * </ul>
+ *
+ * <p>The validation logic is "safe": it does not attempt to load enum classes
+ * directly, which allows it to operate in restricted environments (e.g. LSP,
+ * sandboxed, or remote execution).</p>
+ */
+public class EnumTypeConverterValidator implements ConverterValidator {
+
+    private static final String ENUM_ERROR_MESSAGE =
+            "SRCFG00049: Cannot convert %s to enum class %s, allowed values: %s";
+
+    /** The enum type metadata coming from the BNF/TypeSignatureParser. */
+    private final EnumType enumType;
+
+    /**
+     * A map of hyphenated enum constants → original enum constant name.
+     * Used to support case-insensitive and style-normalized lookups.
+     */
+    private final Map<String, String> values = new HashMap<>();
+
+    /**
+     * Creates a new validator for the given enum type.
+     *
+     * @param enumType the enum type metadata that contains the original
+     *                 enum constant list
+     */
+    public EnumTypeConverterValidator(EnumType enumType) {
+        this.enumType = enumType;
+        updateValues();
+    }
+
+    /**
+     * Refreshes the internal enum constant list based on the result of the
+     * {@link EnumConstantsProvider}. This allows environments where the enum
+     * constants are discovered dynamically without loading the actual enum
+     * class (safe execution mode).
+     *
+     * @param enumConstNamesProvider provider that retrieves the list of
+     *                               enum constants
+     * @param typeProvider unused in this validator, but part of the interface
+     * @param executionMode execution mode (safe, runtime, etc.)
+     */
+    @Override
+    public void refreshEnumType(EnumConstantsProvider enumConstNamesProvider,
+                                TypeProvider typeProvider,
+                                ExecutionMode executionMode) {
+
+        List<String> enumConstants =
+                enumConstNamesProvider.getConstants(enumType.getTypeName());
+
+        if (!Objects.equals(enumType.getEnumConstants(), enumConstants)) {
+            enumType.setEnumConstNames(enumConstants);
+            updateValues();
+        }
+    }
+
+    /**
+     * Validates that the given string corresponds to a known enum constant.
+     * <p>
+     * Validation is performed on the {@code hyphenated} representation of the
+     * value. For example:
+     * <pre>
+     *   "MyValue" → "my-value"
+     * </pre>
+     *
+     * @param value    the string to validate
+     * @param start    the starting offset of the value in the document
+     * @param collector collects validation errors for reporting in the client
+     */
+    @Override
+    public void validate(String value, int start, DiagnosticsCollector collector) {
+        final String trimmedValue = value.trim();
+        if (trimmedValue.isEmpty()) {
+            return;
+        }
+
+        final String hyphenatedValue = hyphenate(trimmedValue);
+        final String enumValue = values.get(hyphenatedValue);
+
+        if (enumValue != null) {
+            return; // Valid enum
+        }
+
+        String errorMessage = String.format(
+                ENUM_ERROR_MESSAGE,
+                value,
+                enumType.getTypeName(),
+                String.join(",", values.keySet())
+        );
+
+        collector.collect(errorMessage,
+                "microprofile-config",
+                "value",
+                start,
+                value.length());
+    }
+
+    /**
+     * Updates the internal map of hyphenated values to enum names.
+     * This is used after initial creation and after each refresh.
+     */
+    private void updateValues() {
+        values.clear();
+        for (String enumValue : this.enumType.getEnumConstants()) {
+            values.put(hyphenate(enumValue), enumValue);
+        }
+    }
+
+    /**
+     * Hyphenates a value using SmallRye’s {@link StringUtil#skewer(String)}
+     * (original logic preserved exactly as in the source).
+     *
+     * @param value the original enum constant or user value
+     * @return the hyphenated / normalized form
+     */
+    private static String hyphenate(String value) {
+        return StringUtil.skewer(value);
+    }
+
+    /**
+     * This validator always supports validation of enum types.
+     *
+     * @return true
+     */
+    @Override
+    public boolean canValidate() {
+        return true;
+    }
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/config/java/MicroProfileConfigJavaDiagnosticsTest.java
@@ -64,7 +64,8 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
 		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
 
-		// Error message like "SRCFG00029: Expected an integer value, got \"foo\"" commes from SmallRyeConfig
+		// Error message like "SRCFG00029: Expected an integer value, got \"foo\""
+		// commes from SmallRyeConfig
 		Diagnostic d1 = d(10, 56, 59, "SRCFG00029: Expected an integer value, got \"foo\"", DiagnosticSeverity.Error,
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
@@ -76,6 +77,7 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 		Diagnostic d3 = d(19, 56, 59, "Value out of range. Value:\"128\" Radix:10", DiagnosticSeverity.Error,
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
 		Diagnostic d4 = d(34, 27, 38,
 				"The property 'greeting9' is not assigned a value in any config file, and must be assigned at runtime.",
 				DiagnosticSeverity.Warning, MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
@@ -86,23 +88,21 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
-		/*
-		 * Diagnostic d6 = d(52, 83, 86,
-		 * "No enum constant org.acme.config.DefaultValueResource.ProcessingLevel.FOO",
-		 * DiagnosticSeverity.Error,
-		 * MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
-		 * MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
-		 */
+		Diagnostic d6 = d(52, 83, 86,
+				"SRCFG00049: Cannot convert FOO to enum class org.acme.config.DefaultValueResource$ProcessingLevel, allowed values: all,messages,messages-persist",
+				DiagnosticSeverity.Error, MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
 		Diagnostic d7 = d(58, 62, 67, "Text '00-00' could not be parsed at index 2", DiagnosticSeverity.Error,
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
-		Diagnostic d8 = d(64, 65, 70, "Text cannot be parsed to a Duration",
-				DiagnosticSeverity.Error, MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+		Diagnostic d8 = d(64, 65, 70, "Text cannot be parsed to a Duration", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
 		assertJavaDiagnostics(diagnosticsParams, utils, //
-				d1, d2, d3, d4, d5, /* d6, */ d7, d8);
+				d1, d2, d3, d4, d5, d6, d7, d8);
 	}
 
 	@Test
@@ -158,7 +158,8 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 		diagnosticsParams.setUris(Arrays.asList(javaFile.getLocation().toFile().toURI().toString()));
 		diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
 
-		// Error message like "SRCFG00029: Expected an integer value, got \"foo\"" commes from SmallRyeConfig
+		// Error message like "SRCFG00029: Expected an integer value, got \"foo\""
+		// commes from SmallRyeConfig
 		Diagnostic d1 = d(10, 56, 59, "SRCFG00029: Expected an integer value, got \"foo\"", DiagnosticSeverity.Error,
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
@@ -184,23 +185,21 @@ public class MicroProfileConfigJavaDiagnosticsTest extends BasePropertiesManager
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
-		/*
-		 * Diagnostic d6 = d(52, 83, 86,
-		 * "No enum constant org.acme.config.DefaultValueResource.ProcessingLevel.FOO",
-		 * DiagnosticSeverity.Error,
-		 * MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
-		 * MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
-		 */
+		Diagnostic d6 = d(52, 83, 86,
+				"SRCFG00049: Cannot convert FOO to enum class org.acme.config.DefaultValueResource$ProcessingLevel, allowed values: all,messages,messages-persist",
+				DiagnosticSeverity.Error, MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
+
 		Diagnostic d7 = d(58, 62, 67, "Text '00-00' could not be parsed at index 2", DiagnosticSeverity.Error,
 				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
-		Diagnostic d8 = d(64, 65, 70, "Text cannot be parsed to a Duration",
-				DiagnosticSeverity.Error, MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
+		Diagnostic d8 = d(64, 65, 70, "Text cannot be parsed to a Duration", DiagnosticSeverity.Error,
+				MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE,
 				MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE);
 
 		assertJavaDiagnostics(diagnosticsParams, utils, //
-				d1, d2, d3, d5, /* d6, */ d7, d8);
+				d1, d2, d3, d5, d6, d7, d8);
 
 	}
 

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileProjectInfo.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/MicroProfileProjectInfo.java
@@ -14,9 +14,14 @@
 package org.eclipse.lsp4mp.commons;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collector;
 
 import org.eclipse.lsp4mp.commons.metadata.ConfigurationMetadata;
+import org.eclipse.lsp4mp.commons.metadata.ItemHint;
+import org.eclipse.lsp4mp.commons.metadata.ValueHint;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
 
 /**
  * MicroProfile Project Information
@@ -24,7 +29,7 @@ import org.eclipse.lsp4mp.commons.metadata.ConfigurationMetadata;
  * @author Angelo ZERR
  *
  */
-public class MicroProfileProjectInfo extends ConfigurationMetadata {
+public class MicroProfileProjectInfo extends ConfigurationMetadata implements EnumConstantsProvider {
 
 	public static final MicroProfileProjectInfo EMPTY_PROJECT_INFO;
 
@@ -38,7 +43,7 @@ public class MicroProfileProjectInfo extends ConfigurationMetadata {
 	private String projectURI;
 
 	private ClasspathKind classpathKind;
-	
+
 	private Set<String> classpath;
 
 	/**
@@ -80,8 +85,22 @@ public class MicroProfileProjectInfo extends ConfigurationMetadata {
 	public Set<String> getClasspath() {
 		return classpath;
 	}
-	
+
 	public void setClasspath(Set<String> classpath) {
 		this.classpath = classpath;
+	}
+
+	@Override
+	public List<String> getConstants(String enumType) {
+		ItemHint hint = getHint(enumType);
+		if (hint != null) {
+			return hint
+					.getValues()
+					.stream()
+					.map(ValueHint::getValue)
+					.toList();
+					
+		}
+		return null;
 	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/DiagnosticsCollector.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/DiagnosticsCollector.java
@@ -11,7 +11,9 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.lsp4mp.commons.runtime.converter;
+package org.eclipse.lsp4mp.commons.runtime;
+
+import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
 
 /**
  * Functional interface used to collect diagnostics produced during the

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/EnumConstantsProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/EnumConstantsProvider.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides the list of constant names for a given enum type.
+ *
+ * <p>
+ * This functional interface is used by the MicroProfile runtime support to 
+ * resolve the allowed values of an enum when validating property values.
+ * </p>
+ *
+ * <p>
+ * The behavior depends on the execution mode:
+ * </p>
+ * <ul>
+ *   <li><b>FULL mode</b>: Implementations may attempt to load the enum class 
+ *       from the project classpath and return its declared constants.</li>
+ *   <li><b>SAFE mode</b>: Implementations cannot access project classes. In 
+ *       this case, constants may be resolved from fallback mechanisms 
+ *       (e.g., SmallRye Config hosted in the Language Server) or may return 
+ *       an empty list if the enum type is unknown.</li>
+ * </ul>
+ *
+ * <p>
+ * Returning an empty list never causes a failure by itself: it simply means 
+ * the validator cannot offer enum-aware validation for that type.
+ * </p>
+ */
+@FunctionalInterface
+public interface EnumConstantsProvider {
+
+	public static class SimpleEnumConstantsProvider implements EnumConstantsProvider {
+
+		private Map<String, List<String>> enums;
+		
+		@Override
+		public List<String> getConstants(String enumType) {
+			return enums != null ? enums.get(enumType) : null;
+		}
+		
+		public void addEnumConstants(String enumType, List<String> enumConstNames) {
+			if (enums == null) {
+				enums = new HashMap<>();
+			}
+			enums.put(enumType, enumConstNames);
+		}		
+	}
+	
+    /**
+     * Returns the list of constant names for the given enum type.
+     *
+     * @param enumType the fully qualified name of the enum class
+     * @return the list of enum constant names, or an empty list if the enum cannot be resolved
+     */
+    List<String> getConstants(String enumType);
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/TypeProvider.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/TypeProvider.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime;
+
+import java.lang.reflect.Type;
+
+/**
+ * Resolves a type from its fully qualified name, optionally using an
+ * {@link EnumConstantsProvider} when the target type is an enum.
+ *
+ * <p>
+ * This interface abstracts the mechanism used by the MicroProfile runtime
+ * support and configuration validator to resolve Java types referenced in
+ * configuration metadata. The resolution strategy depends on the
+ * {@link ExecutionMode}:
+ * </p>
+ *
+ * <ul>
+ *   <li><b>FULL mode</b>: The implementation may load classes from the
+ *       project classpath (for example using the project's class loader).
+ *       Custom enums, library enums and other project types can be resolved.</li>
+ *
+ *   <li><b>SAFE mode</b>: The project classpath is not used. No reflection
+ *       is allowed. Implementations must avoid loading project classes.
+ *       Types may be resolved only through known built-in types or metadata
+ *       provided by the Language Server (e.g. SmallRye Config hosted by the LS).
+ *       Custom project types generally cannot be resolved.</li>
+ * </ul>
+ *
+ * <p>
+ * When the given type represents an enum and cannot be loaded (e.g. in SAFE
+ * mode or if the type is unknown), the provided
+ * {@link EnumConstantsProvider} may be consulted as a fallback to retrieve
+ * the list of allowed enum constants, enabling partial validation even
+ * without runtime class loading.
+ * </p>
+ *
+ * <p>
+ * If the type cannot be resolved, implementations may return {@code null}.
+ * Validation logic should treat a {@code null} type as "unknown type".
+ * </p>
+ */
+public interface TypeProvider {
+
+    /**
+     * Resolves the Java {@link Type} corresponding to the given fully
+     * qualified type name.
+     *
+     * @param type the fully qualified name of the target type
+     * @param enumConstNamesProvider provider used to retrieve enum constants
+     *        when the type represents an enum but cannot be loaded
+     * @param executionMode determines whether project classpath and reflection
+     *        are allowed ({@code FULL}) or forbidden ({@code SAFE})
+     * @return the resolved {@link Type}, or {@code null} if it cannot be resolved
+     */
+    Type findType(String type,
+                       EnumConstantsProvider enumConstNamesProvider,
+                       ExecutionMode executionMode);
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/AbstractConverterValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/AbstractConverterValidator.java
@@ -17,6 +17,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+
 /**
  * Base class for implementing a MicroProfile Config value validator with
  * conversion support.
@@ -49,7 +51,7 @@ public abstract class AbstractConverterValidator<T> implements ConverterValidato
 	private final T config;
 
 	/** The target type for conversion */
-	private final Class<?> forType;
+	private Class<?> forType;
 
 	/** Indicates whether the validator has been prepared */
 	private boolean prepared;

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterRuntimeSupportApi.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterRuntimeSupportApi.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
 import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
 import org.eclipse.lsp4mp.commons.runtime.MicroProfileRuntimeSupport;
 
@@ -91,9 +93,12 @@ public interface ConverterRuntimeSupportApi extends MicroProfileRuntimeSupport {
 	 * </li>
 	 * </ul>
 	 *
-	 * @param value     the raw configuration value to validate
-	 * @param type      the fully-qualified type name expected
-	 * @param collector the diagnostics collector used to report validation errors
+	 * @param value          the raw configuration value to validate
+	 * @param type           the fully-qualified type name expected
+	 * @param enumConstNames
+	 * @param collector      the diagnostics collector used to report validation
+	 *                       errors
 	 */
-	void validate(String value, String type, DiagnosticsCollector collector);
+	void validate(String value, String type, EnumConstantsProvider enumConstNamesProvider,
+			DiagnosticsCollector collector);
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/ConverterValidator.java
@@ -13,6 +13,11 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter;
 
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
+
 /**
  * Represents a validator that can check a string value against a specific type
  * using the project's MicroProfile Config converters.
@@ -25,29 +30,34 @@ package org.eclipse.lsp4mp.commons.runtime.converter;
  */
 public interface ConverterValidator {
 
-    /**
-     * Validates the given value and collects diagnostics if the value is invalid.
-     *
-     * @param value     the string value to validate
-     * @param start     the start offset in the source (for diagnostics)
-     * @param collector collector used to report validation errors
-     */
-    void validate(String value, int start, DiagnosticsCollector collector);
+	/**
+	 * Validates the given value and collects diagnostics if the value is invalid.
+	 *
+	 * @param value     the string value to validate
+	 * @param start     the start offset in the source (for diagnostics)
+	 * @param collector collector used to report validation errors
+	 */
+	void validate(String value, int start, DiagnosticsCollector collector);
 
-    /**
-     * Validates the given value assuming start offset 0.
-     *
-     * @param value     the string value to validate
-     * @param collector collector used to report validation errors
-     */
-    default void validate(String value, DiagnosticsCollector collector) {
-        validate(value, 0, collector);
-    }
+	/**
+	 * Validates the given value assuming start offset 0.
+	 *
+	 * @param value     the string value to validate
+	 * @param collector collector used to report validation errors
+	 */
+	default void validate(String value, DiagnosticsCollector collector) {
+		validate(value, 0, collector);
+	}
 
-    /**
-     * Indicates whether this validator is ready to perform validation.
-     *
-     * @return true if the validator can validate values for its type, false otherwise
-     */
-    boolean canValidate();
+	default void refreshEnumType(EnumConstantsProvider enumConstNamesProvider, TypeProvider typeProvider, ExecutionMode executionMode) {
+		// Do nothing
+	}
+	
+	/**
+	 * Indicates whether this validator is ready to perform validation.
+	 *
+	 * @return true if the validator can validate values for its type, false
+	 *         otherwise
+	 */
+	boolean canValidate();
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/full/FullConverterValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/full/FullConverterValidator.java
@@ -16,6 +16,9 @@ package org.eclipse.lsp4mp.commons.runtime.converter.full;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
 import org.eclipse.lsp4mp.commons.runtime.converter.AbstractConverterValidator;
 import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
 
@@ -133,5 +136,20 @@ class FullConverterValidator extends AbstractConverterValidator<Object> {
 		this.getConverterMethod = getConverter;
 		this.convertMethod = convert;
 		return true;
+	}
+
+	@Override
+	public void refreshEnumType(EnumConstantsProvider enumConstNamesProvider, TypeProvider typeProvider,
+			ExecutionMode executionMode) {
+		Class<?> forType = getForType();
+		if (forType != null && forType.isEnum()) {
+			forType = (Class<?>) typeProvider.findType(forType.getTypeName(), enumConstNamesProvider,
+					executionMode);
+			try {
+				initialize();
+			} catch (Exception e) {
+				// Do nothing
+			}
+		}
 	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/EnumTypeConverterValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/EnumTypeConverterValidator.java
@@ -1,0 +1,169 @@
+/******************************************************************************
+ *  EnumTypeConverterValidator
+ *  ---------------------------------------------------------------------------
+ *  This file is part of the MicroProfile / SmallRye configuration validation
+ *  system (safe runtime conversion).
+ *
+ *  It validates that a given string value corresponds to an existing enum
+ *  constant, using the hyphenated convention (e.g. "MY_VALUE" → "my-value").
+ *
+ *  Original code preserved; only documentation and file header added.
+ ******************************************************************************/
+
+package org.eclipse.lsp4mp.commons.runtime.converter.safe;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.lsp4mp.commons.runtime.DiagnosticsCollector;
+import org.eclipse.lsp4mp.commons.runtime.EnumConstantsProvider;
+import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
+import org.eclipse.lsp4mp.commons.runtime.TypeProvider;
+import org.eclipse.lsp4mp.commons.runtime.TypeSignatureParser.EnumType;
+import org.eclipse.lsp4mp.commons.runtime.converter.ConverterValidator;
+
+import io.smallrye.config.common.utils.StringUtil;
+
+/**
+ * A {@link ConverterValidator} implementation dedicated to validating that a
+ * user-provided string corresponds to a valid enumeration constant.
+ * <p>
+ * This validator:
+ * <ul>
+ *   <li>Normalizes input values using the hyphenation convention
+ *       (via {@code StringUtil.skewer()}).</li>
+ *   <li>Supports dynamic refresh of enum constants through
+ *       {@link EnumConstantsProvider}.</li>
+ *   <li>Reports diagnostics when the provided value does not match any known
+ *       enum constant.</li>
+ * </ul>
+ *
+ * <p>The validation logic is "safe": it does not attempt to load enum classes
+ * directly, which allows it to operate in restricted environments (e.g. LSP,
+ * sandboxed, or remote execution).</p>
+ */
+public class EnumTypeConverterValidator implements ConverterValidator {
+
+    private static final String ENUM_ERROR_MESSAGE =
+            "SRCFG00049: Cannot convert %s to enum class %s, allowed values: %s";
+
+    /** The enum type metadata coming from the BNF/TypeSignatureParser. */
+    private final EnumType enumType;
+
+    /**
+     * A map of hyphenated enum constants → original enum constant name.
+     * Used to support case-insensitive and style-normalized lookups.
+     */
+    private final Map<String, String> values = new HashMap<>();
+
+    /**
+     * Creates a new validator for the given enum type.
+     *
+     * @param enumType the enum type metadata that contains the original
+     *                 enum constant list
+     */
+    public EnumTypeConverterValidator(EnumType enumType) {
+        this.enumType = enumType;
+        updateValues();
+    }
+
+    /**
+     * Refreshes the internal enum constant list based on the result of the
+     * {@link EnumConstantsProvider}. This allows environments where the enum
+     * constants are discovered dynamically without loading the actual enum
+     * class (safe execution mode).
+     *
+     * @param enumConstNamesProvider provider that retrieves the list of
+     *                               enum constants
+     * @param typeProvider unused in this validator, but part of the interface
+     * @param executionMode execution mode (safe, runtime, etc.)
+     */
+    @Override
+    public void refreshEnumType(EnumConstantsProvider enumConstNamesProvider,
+                                TypeProvider typeProvider,
+                                ExecutionMode executionMode) {
+
+        List<String> enumConstants =
+                enumConstNamesProvider.getConstants(enumType.getTypeName());
+
+        if (!Objects.equals(enumType.getEnumConstants(), enumConstants)) {
+            enumType.setEnumConstNames(enumConstants);
+            updateValues();
+        }
+    }
+
+    /**
+     * Validates that the given string corresponds to a known enum constant.
+     * <p>
+     * Validation is performed on the {@code hyphenated} representation of the
+     * value. For example:
+     * <pre>
+     *   "MyValue" → "my-value"
+     * </pre>
+     *
+     * @param value    the string to validate
+     * @param start    the starting offset of the value in the document
+     * @param collector collects validation errors for reporting in the client
+     */
+    @Override
+    public void validate(String value, int start, DiagnosticsCollector collector) {
+        final String trimmedValue = value.trim();
+        if (trimmedValue.isEmpty()) {
+            return;
+        }
+
+        final String hyphenatedValue = hyphenate(trimmedValue);
+        final String enumValue = values.get(hyphenatedValue);
+
+        if (enumValue != null) {
+            return; // Valid enum
+        }
+
+        String errorMessage = String.format(
+                ENUM_ERROR_MESSAGE,
+                value,
+                enumType.getTypeName(),
+                String.join(",", values.keySet())
+        );
+
+        collector.collect(errorMessage,
+                "microprofile-config",
+                "value",
+                start,
+                value.length());
+    }
+
+    /**
+     * Updates the internal map of hyphenated values to enum names.
+     * This is used after initial creation and after each refresh.
+     */
+    private void updateValues() {
+        values.clear();
+        for (String enumValue : this.enumType.getEnumConstants()) {
+            values.put(hyphenate(enumValue), enumValue);
+        }
+    }
+
+    /**
+     * Hyphenates a value using SmallRye’s {@link StringUtil#skewer(String)}
+     * (original logic preserved exactly as in the source).
+     *
+     * @param value the original enum constant or user value
+     * @return the hyphenated / normalized form
+     */
+    private static String hyphenate(String value) {
+        return StringUtil.skewer(value);
+    }
+
+    /**
+     * This validator always supports validation of enum types.
+     *
+     * @return true
+     */
+    @Override
+    public boolean canValidate() {
+        return true;
+    }
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileValidator.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileValidator.java
@@ -259,7 +259,7 @@ class PropertiesFileValidator {
 					.getProjectRuntime();
 			if (projectRuntime != null) {
 				ExecutionMode preferredMode = executionSettings.getExecutionMode();
-				projectRuntime.validateValue(value, metadata.getType(), preferredMode,
+				projectRuntime.validateValue(value, metadata.getType(), projectInfo, preferredMode,
 						(errorMessage, source, code, converterStart, converterEnd) -> {
 							Range range = PositionUtils.createRange(start + converterStart,
 									start + converterStart + converterEnd, propertiesModel.getDocument());
@@ -379,10 +379,6 @@ class PropertiesFileValidator {
 				}
 			}
 		}
-	}
-
-	private static boolean isBuildtimePlaceholder(String str) {
-		return str.startsWith("${") && str.endsWith("}");
 	}
 
 	private void addDiagnosticsForDuplicates() {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/AbstractProjectRuntimeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/AbstractProjectRuntimeTest.java
@@ -13,9 +13,12 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime;
 
+import static org.eclipse.lsp4mp.services.properties.PropertiesFileAssert.getDefaultMicroProfileProjectInfo;
+
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.runtime.converter.ConverterRuntimeSupportApi;
 import org.junit.Assert;
 
@@ -33,15 +36,20 @@ public abstract class AbstractProjectRuntimeTest {
 	}
 
 	public void assertValiateWithConverter(String value, String type, String... expectedMessages) {
+		assertValiateWithConverter(value, type, getDefaultMicroProfileProjectInfo(), expectedMessages);
+	}
+
+	public void assertValiateWithConverter(String value, String type, MicroProfileProjectInfo projectInfo,
+			String... expectedMessages) {
 		ConverterRuntimeSupportApi converterRuntimeSupport = projectRuntime
 				.getRuntimeSupport(ConverterRuntimeSupportApi.class, executionMode);
 		final List<String> actualMessages = new ArrayList<>();
-		converterRuntimeSupport.validate(value, type, (errorMessage, source, errorCode, start, end) -> {
+		converterRuntimeSupport.validate(value, type, projectInfo, (errorMessage, source, errorCode, start, end) -> {
 			actualMessages.add(errorMessage);
 		});
 		Assert.assertArrayEquals("", expectedMessages, actualMessages.toArray());
 	}
-	
+
 	public ExecutionMode getExecutionMode() {
 		return executionMode;
 	}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/TypeSignatureParserTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/TypeSignatureParserTest.java
@@ -122,8 +122,6 @@ public class TypeSignatureParserTest {
 
     @Test
     public void testInvalidClassName() {
-        assertThrows(IllegalArgumentException.class, () ->
-                TypeSignatureParser.parse("com.does.not.Exist<Something>")
-        );
+        TypeSignatureParser.parse("com.does.not.Exist<Something>");
     }
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInFullModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInFullModeTest.java
@@ -78,19 +78,4 @@ public class LibertyProjectRuntimeInFullModeTest extends AbstractMicroProfilePro
 				"SRCFG00049: Cannot convert FOOX to enum class org.acme.MyEnum, allowed values: bar,foo");
 	}
 
-	/**
-	 * Tests enum conversion for enums defined in JAR dependencies.
-	 * <p>
-	 * Enums from external JARs are not available in Liberty project classpath, so
-	 * validation cannot be fully performed.
-	 * </p>
-	 */
-	@Test
-	public void testEnumFromJAR() {
-		// Enum value valid
-		assertValiateWithConverter("BLOCK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-
-		// Invalid enum value is not fully validated
-		assertValiateWithConverter("BLACK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInSafeModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInSafeModeTest.java
@@ -71,19 +71,4 @@ public class LibertyProjectRuntimeInSafeModeTest extends AbstractMicroProfilePro
 		assertValiateWithConverter("FOOX", "org.acme.MyEnum");
 	}
 
-	/**
-	 * Tests enum conversion for enums defined in JAR dependencies.
-	 * <p>
-	 * In SAFE mode, enums from project JARs cannot be validated because the JARs
-	 * are not on the classpath.
-	 * </p>
-	 */
-	@Test
-	public void testEnumFromJAR() {
-		// Enum value valid
-		assertValiateWithConverter("BLOCK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-
-		// Invalid enum value cannot be validated properly in SAFE mode
-		assertValiateWithConverter("BLACK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-	}
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInFullModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInFullModeTest.java
@@ -69,21 +69,4 @@ public class QuarkusProjectRuntimeInFullModeTest extends AbstractMicroProfilePro
 				"SRCFG00049: Cannot convert FOOX to enum class org.acme.MyEnum, allowed values: bar,foo");
 	}
 
-	/**
-	 * Tests enum conversion for enums defined in JAR dependencies.
-	 * <p>
-	 * In FULL mode, enums from project JARs can be fully validated using reflection
-	 * and the project MicroProfile Config implementation.
-	 * </p>
-	 */
-	@Test
-	public void testEnumFromJAR() {
-		// Enum value valid
-		assertValiateWithConverter("BLOCK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-
-		// Invalid enum value triggers validation error
-		assertValiateWithConverter("BLACK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction",
-				"SRCFG00049: Cannot convert BLACK to enum class org.jboss.logmanager.handlers.AsyncHandler$OverflowAction, allowed values: discard,block");
-	}
-
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInSafeModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInSafeModeTest.java
@@ -71,19 +71,4 @@ public class QuarkusProjectRuntimeInSafeModeTest extends AbstractMicroProfilePro
 		assertValiateWithConverter("FOOX", "org.acme.MyEnum");
 	}
 
-	/**
-	 * Tests enum conversion for enums defined in JAR dependencies.
-	 * <p>
-	 * In SAFE mode, enums from project JARs cannot be fully validated because
-	 * project JARs are not included in the classpath.
-	 * </p>
-	 */
-	@Test
-	public void testEnumFromJAR() {
-		// Enum value valid (basic check with default SmallRye Config)
-		assertValiateWithConverter("BLOCK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-
-		// Enum from JAR cannot be fully validated in SAFE mode
-		assertValiateWithConverter("BLACK", "org.jboss.logmanager.handlers.AsyncHandler$OverflowAction");
-	}
 }


### PR DESCRIPTION
### Support for Enum Value Validation in Safe Mode

In safe mode, the `Enum` class cannot be loaded, which prevents proper validation of enum values.

However, enumeration constant names can still be retrieved from JDT, IntelliJ, and properties files (via `HintValue`).  
This PR introduces built-in validation in the enum converter by using the available enumeration constant names.

Here the result in safe mode (the enum class is not loaded from classpath and in this case converter uses values retrieved from JDT):

![DemoWithEnumValidation](https://github.com/user-attachments/assets/37c0d85d-5c25-460b-9473-0ca72ccd0ecb)

