### PR TITLE
Skip tests for jdt component on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
           stages {
             stage("Build LSP4MP JDT.LS extension"){
               steps {
-                sh 'cd microprofile.jdt && ./mvnw clean verify -B  -Peclipse-sign && cd ..'
+                sh 'cd microprofile.jdt && ./mvnw clean verify -B -DskipTests -Peclipse-sign && cd ..'
               }
             }
             stage('Deploy to downloads.eclipse.org') {


### PR DESCRIPTION
There are some flakey tests, which means the Jenkins build fails and prereleases never get published.

We can check the results of the tests from the run on GitHub Actions, and avoid merging PRs if the tests have legitimate failures.