### PR TITLE
Use diagnostics from the context

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/PropertiesManagerForJava.java
@@ -339,7 +339,7 @@ public class PropertiesManagerForJava {
 		}
 
 		// Collect all adapted diagnostics participant
-		JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, documentFormat, settings);
+		JavaDiagnosticsContext context = new JavaDiagnosticsContext(uri, typeRoot, utils, documentFormat, settings, diagnostics);
 		List<JavaDiagnosticsDefinition> definitions = JavaFeaturesRegistry.getInstance().getJavaDiagnosticsDefinitions()
 				.stream().filter(definition -> definition.isAdaptedForDiagnostics(context, monitor))
 				.collect(Collectors.toList());
@@ -350,10 +350,7 @@ public class PropertiesManagerForJava {
 		// Begin, collect, end participants
 		definitions.forEach(definition -> definition.beginDiagnostics(context, monitor));
 		definitions.forEach(definition -> {
-			List<Diagnostic> collectedDiagnostics = definition.collectDiagnostics(context, monitor);
-			if (collectedDiagnostics != null && !collectedDiagnostics.isEmpty()) {
-				diagnostics.addAll(collectedDiagnostics);
-			}
+			definition.collectDiagnostics(context, monitor);			
 		});
 		definitions.forEach(definition -> definition.endDiagnostics(context, monitor));
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -13,11 +13,8 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.core.java.diagnostics;
 
-import java.util.List;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.lsp4j.Diagnostic;
 
 /**
  * Java diagnostics participants API.
@@ -65,11 +62,9 @@ public interface IJavaDiagnosticsParticipant {
 	 * @param context the java diagnostics context
 	 * @param monitor the progress monitor
 	 *
-	 * @return diagnostics list and null otherwise.
-	 *
 	 * @throws CoreException
 	 */
-	List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException;
+	void collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException;
 
 	/**
 	 * End diagnostics collection.

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/diagnostics/JavaDiagnosticsDefinition.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/diagnostics/JavaDiagnosticsDefinition.java
@@ -57,12 +57,11 @@ public class JavaDiagnosticsDefinition extends AbstractJavaFeatureDefinition<IJa
 	}
 
 	@Override
-	public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) {
+	public void collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) {
 		try {
-			return getParticipant().collectDiagnostics(context, monitor);
+			getParticipant().collectDiagnostics(context, monitor);
 		} catch (Exception e) {
-			LOGGER.log(Level.SEVERE, "Error while collecting diagnostics", e);
-			return null;
+			LOGGER.log(Level.SEVERE, "Error while collecting diagnostics", e);			
 		}
 	}
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/JavaASTDiagnosticsParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/validators/JavaASTDiagnosticsParticipant.java
@@ -14,11 +14,9 @@
 package org.eclipse.lsp4mp.jdt.internal.core.java.validators;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.lsp4j.Diagnostic;
@@ -38,14 +36,7 @@ import org.eclipse.lsp4mp.jdt.core.java.validators.JavaASTValidator;
 public class JavaASTDiagnosticsParticipant implements IJavaDiagnosticsParticipant {
 
 	@Override
-	public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor)
-			throws CoreException {
-		collectDiagnosticsInFile(context, monitor);
-		return context.getDiagnostics();
-	}
-
-	private static void collectDiagnosticsInFile(JavaDiagnosticsContext context, IProgressMonitor monitor)
-			throws JavaModelException {
+	public void collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException {
 		// Collect the list of JavaASTValidator which are adapted for the current AST
 		// compilation unit to validate.
 		Collection<ASTVisitor> validators = JavaASTValidatorRegistry.getInstance().getValidators(context, monitor);

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
@@ -13,35 +13,30 @@
 *******************************************************************************/
 package org.eclipse.lsp4mp.jdt.internal.metrics.java;
 
-import java.util.ArrayList;
-import java.util.List;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAKARTA_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAVAX_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DIAGNOSTIC_SOURCE;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.GAUGE_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.METRIC_ID;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAKARTA_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAVAX_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAKARTA_ANNOTATION;
+import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAVAX_ANNOTATION;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4mp.commons.DocumentFormat;
 import org.eclipse.lsp4mp.jdt.core.java.diagnostics.IJavaDiagnosticsParticipant;
 import org.eclipse.lsp4mp.jdt.core.java.diagnostics.JavaDiagnosticsContext;
 import org.eclipse.lsp4mp.jdt.core.utils.AnnotationUtils;
-import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
 import org.eclipse.lsp4mp.jdt.core.utils.JDTTypeUtils;
 import org.eclipse.lsp4mp.jdt.core.utils.PositionUtils;
-
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.METRIC_ID;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.GAUGE_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAVAX_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAVAX_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAVAX_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAKARTA_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAKARTA_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAKARTA_ANNOTATION;
-import static org.eclipse.lsp4mp.jdt.internal.metrics.MicroProfileMetricsConstants.DIAGNOSTIC_SOURCE;
 
 /**
  * 
@@ -69,17 +64,14 @@ public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosti
 	}
 
 	@Override
-	public List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor)
-			throws CoreException {
+	public void collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException {
 		ITypeRoot typeRoot = context.getTypeRoot();
 		IJavaElement[] elements = typeRoot.getChildren();
-		List<Diagnostic> diagnostics = new ArrayList<>();
-		collectDiagnostics(elements, diagnostics, context, monitor);
-		return diagnostics;
+		collectDiagnostics(elements, context, monitor);
 	}
 
-	private static void collectDiagnostics(IJavaElement[] elements, List<Diagnostic> diagnostics,
-			JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException {
+	private static void collectDiagnostics(IJavaElement[] elements, JavaDiagnosticsContext context,
+			IProgressMonitor monitor) throws CoreException {
 		for (IJavaElement element : elements) {
 			if (monitor.isCanceled()) {
 				return;
@@ -87,17 +79,15 @@ public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosti
 			if (element.getElementType() == IJavaElement.TYPE) {
 				IType type = (IType) element;
 				if (!type.isInterface()) {
-					validateClassType(type, diagnostics, context, monitor);
+					validateClassType(type, context, monitor);
 				}
 				continue;
 			}
 		}
 	}
 
-	private static void validateClassType(IType classType, List<Diagnostic> diagnostics, JavaDiagnosticsContext context,
-			IProgressMonitor monitor) throws CoreException {
-		String uri = context.getUri();
-		IJDTUtils utils = context.getUtils();
+	private static void validateClassType(IType classType, JavaDiagnosticsContext context, IProgressMonitor monitor)
+			throws CoreException {
 		DocumentFormat documentFormat = context.getDocumentFormat();
 		boolean hasInvalidScopeAnnotation = AnnotationUtils.hasAnnotation(classType, REQUEST_SCOPED_JAVAX_ANNOTATION)
 				|| AnnotationUtils.hasAnnotation(classType, SESSION_SCOPED_JAVAX_ANNOTATION)
@@ -114,15 +104,14 @@ public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosti
 				}
 				if (element.getElementType() == IJavaElement.METHOD) {
 					IMethod method = (IMethod) element;
-					validateMethod(classType, method, diagnostics, context);
+					validateMethod(classType, method, context);
 				}
 			}
 		}
 	}
 
-	private static void validateMethod(IType classType, IMethod method, List<Diagnostic> diagnostics,
-			JavaDiagnosticsContext context) throws CoreException {
-		String uri = context.getUri();
+	private static void validateMethod(IType classType, IMethod method, JavaDiagnosticsContext context)
+			throws CoreException {
 		DocumentFormat documentFormat = context.getDocumentFormat();
 		boolean hasGaugeAnnotation = AnnotationUtils.hasAnnotation(method, GAUGE_ANNOTATION);
 
@@ -132,9 +121,8 @@ public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosti
 		// Suggest that @AnnotationScoped is used instead.</li>
 		if (hasGaugeAnnotation) {
 			Range cdiBeanRange = PositionUtils.toNameRange(classType, context.getUtils());
-			Diagnostic d = context.createDiagnostic(uri, createDiagnostic1Message(classType, documentFormat),
-					cdiBeanRange, DIAGNOSTIC_SOURCE, MicroProfileMetricsErrorCode.ApplicationScopedAnnotationMissing);
-			diagnostics.add(d);
+			context.addDiagnostic(createDiagnostic1Message(classType, documentFormat), cdiBeanRange, DIAGNOSTIC_SOURCE,
+					MicroProfileMetricsErrorCode.ApplicationScopedAnnotationMissing);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a design error when diagnostics must be collected. The IJavaDiagnosticsParticipant defines a method like:

`List<Diagnostic> collectDiagnostics(JavaDiagnosticsContext context, IProgressMonitor monitor) throws CoreException;`

which returns a list of diagnostics for the given context (a given file uri)

The collectDiagnostics should not return a list of diagnostics and should use `JavaDiagnosticsContext #addDiagnostic`

This PR fixes that and fixes also the file uri which is used when diagnostic is created although diagnostic doesn't store some uri.