### PR TITLE
Use '$' instead of '.' in qualified name.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
@@ -108,7 +108,7 @@ public class JDTTypeUtils {
 		try {
 			String signature = field.getTypeSignature();
 			IType primaryType = field.getTypeRoot().findPrimaryType();
-			return JavaModelUtil.getResolvedTypeName(signature, primaryType);
+			return JavaModelUtil.getResolvedTypeName(signature, primaryType, '$');
 		} catch (JavaModelException e) {
 			return null;
 		}


### PR DESCRIPTION
Use '$' instead of '.' in qualified name.