### PR TITLE
Use '$' instead of '.' in qualified name for method.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/utils/JDTTypeUtils.java
@@ -90,7 +90,7 @@ public class JDTTypeUtils {
 		try {
 			String signature = localVar.getTypeSignature().replace("/", ".");
 			IType primaryType = localVar.getTypeRoot().findPrimaryType();
-			return JavaModelUtil.getResolvedTypeName(signature, primaryType);
+			return JavaModelUtil.getResolvedTypeName(signature, primaryType, '$');
 		} catch (JavaModelException e) {
 			return null;
 		}
@@ -126,7 +126,7 @@ public class JDTTypeUtils {
 		try {
 			String signature = method.getReturnType();
 			IType primaryType = method.getTypeRoot().findPrimaryType();
-			return JavaModelUtil.getResolvedTypeName(signature, primaryType);
+			return JavaModelUtil.getResolvedTypeName(signature, primaryType, '$');
 		} catch (JavaModelException e) {
 			return null;
 		}


### PR DESCRIPTION
Use '$' instead of '.' in qualified name for method.