### PR TITLE
Don't re-trigger Java validation for all opened Java files when a Java file is saved.

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/AbstractConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/AbstractConfigSource.java
@@ -218,7 +218,8 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
 		return null;
 	}
 
-	private void reset() {
+	@Override
+	public void reset() {
 		config = null;
 		propertyInformations = null;
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSource.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/IConfigSource.java
@@ -100,4 +100,5 @@ public interface IConfigSource {
 	 */
 	Set<String> getAllKeys();
 
+	void reset();
 }

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProject.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProject.java
@@ -25,6 +25,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -218,6 +219,29 @@ public class JDTMicroProfileProject {
 		configSources = null;
 		propertyValueExpander = null;
 		aggregatedPropertiesProvider = null;
+	}
+
+	/**
+	 * Try updating the given config source file
+	 * 
+	 * @param file
+	 * @return true if the config source file has been updated (ex:
+	 *         src/main/resources/microprofile-config.properties) and false
+	 *         otherwise (ex: target/classes/microprofile-config.properties)
+	 */
+	public boolean updateConfigSource(IFile file) {
+		if (configSources != null) {
+			for (IConfigSource configSource : configSources) {
+				// If file comes from target folder, the file will not be updated.
+				if (configSource.getSourceConfigFileURI().endsWith(file.getLocation().toString())) {
+					configSource.reset();
+					propertyValueExpander = null;
+					aggregatedPropertiesProvider = null;
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProjectManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/core/project/JDTMicroProfileProjectManager.java
@@ -23,10 +23,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
-import org.eclipse.core.resources.IResourceDelta;
-import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
@@ -52,7 +49,10 @@ public class JDTMicroProfileProjectManager {
 	private final Map<IJavaProject, JDTMicroProfileProject> projects;
 	private MicroProfileProjectListener microprofileProjectListener;
 
-	private class MicroProfileProjectListener implements IResourceChangeListener, IResourceDeltaVisitor {
+	/**
+	 * Resource Listener to update MicroProfile projects cache.
+	 */
+	private class MicroProfileProjectListener implements IResourceChangeListener {
 
 		@Override
 		public void resourceChanged(IResourceChangeEvent event) {
@@ -81,18 +81,6 @@ public class JDTMicroProfileProjectManager {
 				}
 				break;
 			}
-			case IResourceChangeEvent.POST_CHANGE:
-				IResourceDelta resourceDelta = event.getDelta();
-				if (resourceDelta != null) {
-					try {
-						resourceDelta.accept(this);
-					} catch (CoreException e) {
-						if (LOGGER.isLoggable(Level.SEVERE)) {
-							LOGGER.log(Level.SEVERE, "Error while tracking MicroProfile properties file", e);
-						}
-					}
-				}
-				break;
 			}
 		}
 
@@ -102,44 +90,6 @@ public class JDTMicroProfileProjectManager {
 				// Remove the JDTMicroProfile project instance from the cache.
 				projects.remove(javaProject);
 			}
-		}
-
-		@Override
-		public boolean visit(IResourceDelta delta) throws CoreException {
-			IResource resource = delta.getResource();
-			if (resource == null) {
-				return false;
-			}
-			switch (resource.getType()) {
-			case IResource.ROOT:
-			case IResource.PROJECT:
-			case IResource.FOLDER:
-				return resource.isAccessible();
-			case IResource.FILE:
-				IFile file = (IFile) resource;
-				if ((isFileDeleted(delta) || isFileContentChanged(delta) || isFileAdded(delta))
-						&& isConfigSource(file)) {
-					// it's a config source file (ex : microprofile-config.properties)
-					JDTMicroProfileProject mpProject = getJDTMicroProfileProject(file);
-					if (mpProject != null) {
-						// Evict the properties cache
-						mpProject.evictConfigSourcesCache();
-					}
-				}
-			}
-			return false;
-		}
-
-		private boolean isFileDeleted(IResourceDelta delta) {
-			return delta.getKind() == IResourceDelta.REMOVED;
-		}
-
-		private boolean isFileAdded(IResourceDelta delta) {
-			return delta.getKind() == IResourceDelta.ADDED;
-		}
-
-		private boolean isFileContentChanged(IResourceDelta delta) {
-			return (delta.getKind() == IResourceDelta.CHANGED && (delta.getFlags() & IResourceDelta.CONTENT) != 0);
 		}
 
 	}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/MicroProfilePropertiesListenerManager.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/MicroProfilePropertiesListenerManager.java
@@ -189,12 +189,33 @@ public class MicroProfilePropertiesListenerManager {
 						mpProject.getProjectRuntime().clearProjectClassCache();
 					}
 					fireAsyncEvent(event);
-				} else if (isConfigSource(file) && isFileContentChanged(delta)) {
-					MicroProfilePropertiesChangeEvent event = new MicroProfilePropertiesChangeEvent();
-					event.setType(MicroProfilePropertiesScope.ONLY_CONFIG_FILES);
-					event.setProjectURIs(new HashSet<String>());
-					event.getProjectURIs().add(JDTMicroProfileUtils.getProjectURI(file.getProject()));
-					fireAsyncEvent(event);
+				} else if (isConfigSource(file)) {
+					// Create, delete, update config source file (ex :
+					// microprofile-config.properties)
+					
+					JDTMicroProfileProject mpProject = JDTMicroProfileProjectManager.getInstance()
+							.getJDTMicroProfileProject(file);
+					
+					boolean generateEvent = false;
+					if (isFileDeleted(delta) || isFileAdded(delta)) {
+						generateEvent = true;
+						// Create, delete config source file (ex : microprofile-config.properties)						
+						if (mpProject != null) {
+							// Evict the properties cache
+							mpProject.evictConfigSourcesCache();
+						}
+					} else if (isFileContentChanged(delta)) {
+						// Update config source file (ex : microprofile-config.properties)
+						generateEvent = mpProject != null ? mpProject.updateConfigSource(file) : true;
+					}
+
+					if (generateEvent) {
+						MicroProfilePropertiesChangeEvent event = new MicroProfilePropertiesChangeEvent();
+						event.setType(MicroProfilePropertiesScope.ONLY_CONFIG_FILES);
+						event.setProjectURIs(new HashSet<String>());
+						event.getProjectURIs().add(JDTMicroProfileUtils.getProjectURI(file.getProject()));
+						fireAsyncEvent(event);
+					}
 				}
 			}
 			return false;
@@ -275,6 +296,14 @@ public class MicroProfilePropertiesListenerManager {
 
 		private boolean isConfigSource(IFile file) {
 			return JDTMicroProfileProjectManager.getInstance().isConfigSource(file);
+		}
+
+		private boolean isFileDeleted(IResourceDelta delta) {
+			return delta.getKind() == IResourceDelta.REMOVED;
+		}
+
+		private boolean isFileAdded(IResourceDelta delta) {
+			return delta.getKind() == IResourceDelta.ADDED;
 		}
 
 		private boolean isFileContentChanged(IResourceDelta delta) {


### PR DESCRIPTION
Don't re-trigger Java validation for all opened Java files when a Java file is saved.

This PR avoid sending (type=3 which means configFile changed)

```
[Trace - 9:33:16 PM] Sending notification 'microprofile/propertiesChanged'.
Params: {
    "type": [
        3
    ],
    "projectURIs": [
        "C:\\Users\\azerr\\Downloads\\demo\\demo"
    ]
}
```

which retriggers validation of Java files when a Java file is saved.

See https://github.com/redhat-developer/vscode-quarkus/issues/1004#issuecomment-2881352209

# Before this PR

 * when Java file was saved,  'microprofile/propertiesChanged' was sent because `target/classes/application.properties` was updated
 * when src/main/resources/application.properties,  'microprofile/propertiesChanged' was sent twice (one update from `src/main/resources/application.properties` and one update from `target/classes/application.properties`

# After this PR

 * when Java file is saved,  no 'microprofile/propertiesChanged' should be sent.
 * when src/main/resources/application.properties is saved, only one  'microprofile/propertiesChanged' should be sent