### PR TITLE
Accept the relaxed `Duration` format (e.g. `60S`) for SmallRye/Quarkus projects in SAFE mode

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/MicroProfileProjectRuntime.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/MicroProfileProjectRuntime.java
@@ -171,6 +171,30 @@ public class MicroProfileProjectRuntime implements TypeProvider {
 	}
 
 	/**
+	 * Returns {@code true} if the project classpath contains an entry whose name
+	 * contains the given {@code token} (typically an artifact file name).
+	 *
+	 * <p>
+	 * Only the classpath entry names are inspected; no class is loaded, so this can
+	 * safely be used in SAFE execution mode.
+	 * </p>
+	 *
+	 * @param token the substring to look for in the classpath entry names
+	 * @return {@code true} if a classpath entry contains the given token
+	 */
+	public boolean hasClasspathEntry(String token) {
+		if (classpath == null || token == null) {
+			return false;
+		}
+		for (String entry : classpath) {
+			if (entry != null && entry.contains(token)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Retrieves the Class corresponding to the given fully qualified name. Uses an
 	 * internal cache to avoid reloading the same class multiple times.
 	 *

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/DurationConverter.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/DurationConverter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime.converter.safe;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Converter for {@link Duration} used in SAFE execution mode.
+ *
+ * <p>
+ * In addition to the ISO-8601 representation (e.g. {@code PT60S}), it accepts the
+ * relaxed format used by Quarkus/SmallRye configuration:
+ * </p>
+ * <ul>
+ * <li>a bare number is interpreted as a number of seconds ({@code 60});</li>
+ * <li>a value starting with a digit is treated as an ISO-8601 duration without the
+ * leading {@code PT} ({@code 60S}, {@code 10m}, {@code 3h});</li>
+ * <li>any other value is parsed as ISO-8601 ({@code PT1H30M}).</li>
+ * </ul>
+ *
+ * <p>
+ * SmallRye Config does not register an explicit converter for {@link Duration}, so
+ * SAFE mode would otherwise fall back to {@link Duration#parse(CharSequence)}, which
+ * only accepts the strict ISO-8601 format. This mirrors the behavior of the Quarkus
+ * {@code DurationConverter} that is used in FULL mode.
+ */
+public class DurationConverter implements Converter<Duration> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
+
+	private static final Pattern START_WITH_DIGITS = Pattern.compile("^[-+]?\\d.*$");
+
+	@Override
+	public Duration convert(String value) {
+		if (value == null) {
+			return null;
+		}
+		value = value.trim();
+		if (value.isEmpty()) {
+			return null;
+		}
+		if (DIGITS.matcher(value).matches()) {
+			return Duration.ofSeconds(Long.parseLong(value));
+		}
+		if (START_WITH_DIGITS.matcher(value).matches()) {
+			return Duration.parse("PT" + value);
+		}
+		return Duration.parse(value);
+	}
+}

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/SafeConverterRuntimeSupport.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/SafeConverterRuntimeSupport.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter.safe;
 
+import java.time.Duration;
+
 import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
 import org.eclipse.lsp4mp.commons.runtime.MicroProfileProjectRuntime;
 import org.eclipse.lsp4mp.commons.runtime.converter.AbstractConverterRuntimeSupport;
@@ -47,6 +49,11 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 public class SafeConverterRuntimeSupport extends AbstractConverterRuntimeSupport<Config> {
 
 	/**
+	 * Classpath token identifying a project that uses SmallRye Config (e.g. Quarkus).
+	 */
+	private static final String SMALLRYE_CONFIG = "smallrye-config";
+
+	/**
 	 * Constructs a new SAFE runtime support instance for the given project.
 	 *
 	 * @param project the owning MicroProfile project runtime
@@ -62,7 +69,14 @@ public class SafeConverterRuntimeSupport extends AbstractConverterRuntimeSupport
 	 */
 	@Override
 	protected Config loadConfig() {
-		return new SmallRyeConfigBuilder().build();
+		SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+		// The relaxed Duration format (e.g. "60S", or a bare number interpreted as seconds) is a
+		// SmallRye Config / Quarkus convention. Only enable it when the project actually uses SmallRye
+		// Config, so that strict MicroProfile runtimes (e.g. Open Liberty) keep ISO-8601 validation.
+		if (getProject().hasClasspathEntry(SMALLRYE_CONFIG)) {
+			builder.withConverter(Duration.class, 100, new DurationConverter());
+		}
+		return builder.build();
 	}
 
 	/**

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/MicroProfileProjectRuntime.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/MicroProfileProjectRuntime.java
@@ -171,6 +171,30 @@ public class MicroProfileProjectRuntime implements TypeProvider {
 	}
 
 	/**
+	 * Returns {@code true} if the project classpath contains an entry whose name
+	 * contains the given {@code token} (typically an artifact file name).
+	 *
+	 * <p>
+	 * Only the classpath entry names are inspected; no class is loaded, so this can
+	 * safely be used in SAFE execution mode.
+	 * </p>
+	 *
+	 * @param token the substring to look for in the classpath entry names
+	 * @return {@code true} if a classpath entry contains the given token
+	 */
+	public boolean hasClasspathEntry(String token) {
+		if (classpath == null || token == null) {
+			return false;
+		}
+		for (String entry : classpath) {
+			if (entry != null && entry.contains(token)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Retrieves the Class corresponding to the given fully qualified name. Uses an
 	 * internal cache to avoid reloading the same class multiple times.
 	 *

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/DurationConverter.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/DurationConverter.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4mp.commons.runtime.converter.safe;
+
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.eclipse.microprofile.config.spi.Converter;
+
+/**
+ * Converter for {@link Duration} used in SAFE execution mode.
+ *
+ * <p>
+ * In addition to the ISO-8601 representation (e.g. {@code PT60S}), it accepts the
+ * relaxed format used by Quarkus/SmallRye configuration:
+ * </p>
+ * <ul>
+ * <li>a bare number is interpreted as a number of seconds ({@code 60});</li>
+ * <li>a value starting with a digit is treated as an ISO-8601 duration without the
+ * leading {@code PT} ({@code 60S}, {@code 10m}, {@code 3h});</li>
+ * <li>any other value is parsed as ISO-8601 ({@code PT1H30M}).</li>
+ * </ul>
+ *
+ * <p>
+ * SmallRye Config does not register an explicit converter for {@link Duration}, so
+ * SAFE mode would otherwise fall back to {@link Duration#parse(CharSequence)}, which
+ * only accepts the strict ISO-8601 format. This mirrors the behavior of the Quarkus
+ * {@code DurationConverter} that is used in FULL mode.
+ */
+public class DurationConverter implements Converter<Duration> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
+
+	private static final Pattern START_WITH_DIGITS = Pattern.compile("^[-+]?\\d.*$");
+
+	@Override
+	public Duration convert(String value) {
+		if (value == null) {
+			return null;
+		}
+		value = value.trim();
+		if (value.isEmpty()) {
+			return null;
+		}
+		if (DIGITS.matcher(value).matches()) {
+			return Duration.ofSeconds(Long.parseLong(value));
+		}
+		if (START_WITH_DIGITS.matcher(value).matches()) {
+			return Duration.parse("PT" + value);
+		}
+		return Duration.parse(value);
+	}
+}

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/SafeConverterRuntimeSupport.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/commons/runtime/converter/safe/SafeConverterRuntimeSupport.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4mp.commons.runtime.converter.safe;
 
+import java.time.Duration;
+
 import org.eclipse.lsp4mp.commons.runtime.ExecutionMode;
 import org.eclipse.lsp4mp.commons.runtime.MicroProfileProjectRuntime;
 import org.eclipse.lsp4mp.commons.runtime.converter.AbstractConverterRuntimeSupport;
@@ -47,6 +49,11 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 public class SafeConverterRuntimeSupport extends AbstractConverterRuntimeSupport<Config> {
 
 	/**
+	 * Classpath token identifying a project that uses SmallRye Config (e.g. Quarkus).
+	 */
+	private static final String SMALLRYE_CONFIG = "smallrye-config";
+
+	/**
 	 * Constructs a new SAFE runtime support instance for the given project.
 	 *
 	 * @param project the owning MicroProfile project runtime
@@ -62,7 +69,14 @@ public class SafeConverterRuntimeSupport extends AbstractConverterRuntimeSupport
 	 */
 	@Override
 	protected Config loadConfig() {
-		return new SmallRyeConfigBuilder().build();
+		SmallRyeConfigBuilder builder = new SmallRyeConfigBuilder();
+		// The relaxed Duration format (e.g. "60S", or a bare number interpreted as seconds) is a
+		// SmallRye Config / Quarkus convention. Only enable it when the project actually uses SmallRye
+		// Config, so that strict MicroProfile runtimes (e.g. Open Liberty) keep ISO-8601 validation.
+		if (getProject().hasClasspathEntry(SMALLRYE_CONFIG)) {
+			builder.withConverter(Duration.class, 100, new DurationConverter());
+		}
+		return builder.build();
 	}
 
 	/**

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInSafeModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/liberty/LibertyProjectRuntimeInSafeModeTest.java
@@ -71,4 +71,18 @@ public class LibertyProjectRuntimeInSafeModeTest extends AbstractMicroProfilePro
 		assertValiateWithConverter("FOOX", "org.acme.MyEnum");
 	}
 
+	/**
+	 * A project that does not use SmallRye Config (e.g. Open Liberty) keeps strict
+	 * ISO-8601 {@link java.time.Duration} validation: the relaxed Quarkus/SmallRye
+	 * format is not enabled.
+	 */
+	@Test
+	public void testDuration() {
+		// Strict ISO-8601 is valid
+		assertValiateWithConverter("PT1H30M", "java.time.Duration");
+
+		// The relaxed format is NOT accepted (no SmallRye Config on the classpath)
+		assertValiateWithConverter("60S", "java.time.Duration", "Text cannot be parsed to a Duration");
+	}
+
 }

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInSafeModeTest.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/commons/runtime/quarkus/QuarkusProjectRuntimeInSafeModeTest.java
@@ -71,4 +71,30 @@ public class QuarkusProjectRuntimeInSafeModeTest extends AbstractMicroProfilePro
 		assertValiateWithConverter("FOOX", "org.acme.MyEnum");
 	}
 
+	/**
+	 * Tests the relaxed {@link java.time.Duration} format used by Quarkus/SmallRye.
+	 * <p>
+	 * SmallRye Config does not register an explicit converter for {@link java.time.Duration},
+	 * so SAFE mode relies on the embedded {@code DurationConverter} to accept a bare number
+	 * as seconds and digit-leading values as ISO-8601 durations without the {@code PT} prefix,
+	 * in addition to the strict ISO-8601 form.
+	 * </p>
+	 */
+	@Test
+	public void testDuration() {
+		// Relaxed forms (value starting with a digit is parsed as an ISO-8601 duration without "PT")
+		assertValiateWithConverter("60S", "java.time.Duration");
+		assertValiateWithConverter("10m", "java.time.Duration");
+		assertValiateWithConverter("3h", "java.time.Duration");
+
+		// A bare number is interpreted as a number of seconds
+		assertValiateWithConverter("600", "java.time.Duration");
+
+		// Strict ISO-8601 still works
+		assertValiateWithConverter("PT1H30M", "java.time.Duration");
+
+		// A truly invalid value is still reported
+		assertValiateWithConverter("foo", "java.time.Duration", "Text cannot be parsed to a Duration");
+	}
+
 }


### PR DESCRIPTION
## Summary

In SAFE execution mode, validating a `.properties` value whose type is `java.time.Duration` rejects the relaxed duration format used by Quarkus/SmallRye. For example, a `Duration` property such as:

```properties
quarkus.http.read-timeout=60S
```

is flagged with:

> Text cannot be parsed to a Duration

even though it is valid at runtime. This PR makes SAFE mode accept the same relaxed format that Quarkus/SmallRye accept, while keeping strict ISO-8601 validation for runtimes that do not use SmallRye Config (e.g. Open Liberty).

## Root cause

SAFE mode builds an embedded config via `new SmallRyeConfigBuilder().build()` and validates values through the converter returned by `Config#getConverter(Duration.class)`.

SmallRye Config core does **not** register an explicit converter for `java.time.Duration`, so it falls back to the *implicit* converter, which simply calls `java.time.Duration.parse(value)`. That only accepts strict ISO-8601 (`PT60S`), so relaxed values like `60S`, `10m`, or a bare number (`600`, interpreted as seconds) throw `DateTimeParseException`.

The relaxed parsing lives in the Quarkus `DurationConverter`, which is on the project classpath and is therefore only used in FULL mode. SAFE mode never sees it.

## Changes

- Add `DurationConverter` (in `…commons.runtime.converter.safe`) that mirrors the Quarkus/SmallRye rules:
  - a bare number is interpreted as a number of seconds (`600` → `PT10M`);
  - a value starting with a digit is parsed as an ISO-8601 duration without the leading `PT` (`60S` → `PT60S`, `10m` → `PT10M`);
  - any other value is parsed as strict ISO-8601 (`PT1H30M`).
- Register it in `SafeConverterRuntimeSupport#loadConfig()` **only when the project uses SmallRye Config**, detected via a `smallrye-config` entry on the project classpath. This keeps strict ISO-8601 validation for non-SmallRye runtimes (e.g. Open Liberty).
- Add `MicroProfileProjectRuntime#hasClasspathEntry(String)` — inspects classpath entry *names* only (no class is loaded), so it is safe to use in SAFE mode.

FULL mode is unchanged (it already uses the project's own converter).

The change is applied to both copies of the runtime/converter code: `microprofile.ls` (`org.eclipse.lsp4mp.ls`) and `microprofile.jdt` (`org.eclipse.lsp4mp.jdt.core`).

## Why detect `smallrye-config` rather than "Quarkus"

The relaxed duration format is a SmallRye Config behavior, and Quarkus projects always bundle `smallrye-config-*.jar`. The test `QUARKUS_PROJECT_RUNTIME` classpath itself contains `smallrye-config-*.jar` (and no literal `quarkus-*.jar`), so `smallrye-config` is both the semantically correct and the reliably testable signal.

## Testing

New `testDuration` cases assert the behavior in both directions, and the full SAFE/FULL suites still pass (66 tests, 0 failures):

- `QuarkusProjectRuntimeInSafeModeTest#testDuration` — `60S`, `10m`, `3h`, `600`, `PT1H30M` are accepted; `foo` is still reported.
- `LibertyProjectRuntimeInSafeModeTest#testDuration` — `PT1H30M` is accepted, but `60S` is still reported (no SmallRye Config on the classpath).

| Runtime (SAFE mode) | `60S` | `PT1H30M` |
|---|---|---|
| Quarkus (has SmallRye Config) | accepted | accepted |
| Open Liberty (no SmallRye Config) | rejected (`Text cannot be parsed to a Duration`) | accepted |

## Notes

- No public API is removed; `MicroProfileProjectRuntime#hasClasspathEntry(String)` is additive.
- `DurationConverter` is source/target Java 8 compatible (consistent with the module's `maven.compiler.source/target`).