### PR TITLE
Upgrade JDT LS to 1.60.0 and lsp4j to 1.0.0

### DIFF
--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.text,
  org.apache.commons.lang3
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Bundle-ActivationPolicy: lazy
 Export-Package: io.quarkus.runtime.util,
  org.eclipse.lsp4mp.commons,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/NoValueAssignedToPropertyQuickFix.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/config/java/NoValueAssignedToPropertyQuickFix.java
@@ -142,7 +142,7 @@ public class NoValueAssignedToPropertyQuickFix implements IJavaCodeActionPartici
 		VersionedTextDocumentIdentifier documentId = new VersionedTextDocumentIdentifier(document.getUri(),
 				document.getVersion());
 		TextEdit te = new TextEdit(new Range(position, position), insertText);
-		return new TextDocumentEdit(documentId, Collections.singletonList(te));
+		return new TextDocumentEdit(documentId, Collections.singletonList(Either.forLeft(te)));
 	}
 
 	private static String getPropertyName(Diagnostic diagnostic, JavaCodeActionContext context)

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/ChangeUtil.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/ChangeUtil.java
@@ -112,7 +112,11 @@ public class ChangeUtil {
 			}
 
 			VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, 0);
-			TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, converter.convert());
+			List<Either<org.eclipse.lsp4j.TextEdit, org.eclipse.lsp4j.SnippetTextEdit>> edits = new ArrayList<>();
+			for (org.eclipse.lsp4j.TextEdit te : converter.convert()) {
+			    edits.add(Either.forLeft(te));
+			}
+			TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, edits);
 			changes.add(Either.forLeft(documentEdit));
 		} else {
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/ChangeUtil.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/ChangeUtil.java
@@ -111,12 +111,7 @@ public class ChangeUtil {
 				root.setDocumentChanges(changes);
 			}
 
-			VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, 0);
-			List<Either<org.eclipse.lsp4j.TextEdit, org.eclipse.lsp4j.SnippetTextEdit>> edits = new ArrayList<>();
-			for (org.eclipse.lsp4j.TextEdit te : converter.convert()) {
-			    edits.add(Either.forLeft(te));
-			}
-			TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, edits);
+			TextDocumentEdit documentEdit = converter.convertToTextDocumentEdit(0);
 			changes.add(Either.forLeft(documentEdit));
 		} else {
 

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/TextEditConverter.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/jdt/internal/core/java/TextEditConverter.java
@@ -25,6 +25,8 @@ import org.eclipse.jdt.internal.core.util.SimpleDocument;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.SnippetTextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4mp.jdt.core.utils.IJDTUtils;
 import org.eclipse.text.edits.CopySourceEdit;
@@ -78,9 +80,12 @@ public class TextEditConverter extends TextEditVisitor {
 	}
 
 	public TextDocumentEdit convertToTextDocumentEdit(int version) {
-		VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(version);
-		identifier.setUri(uri);
-		return new TextDocumentEdit(identifier, this.convert());
+	    VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, version);
+	    List<Either<org.eclipse.lsp4j.TextEdit, SnippetTextEdit>> edits = new ArrayList<>();
+	    for (org.eclipse.lsp4j.TextEdit te : this.convert()) {
+	        edits.add(Either.forLeft(te));
+	    }
+	    return new TextDocumentEdit(identifier, edits);
 	}
 
 	/*

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/ls/commons/CodeActionFactory.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.core/src/main/java/org/eclipse/lsp4mp/ls/commons/CodeActionFactory.java
@@ -22,6 +22,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
@@ -86,7 +87,7 @@ public class CodeActionFactory {
 				document.getUri(), document.getVersion());
 
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-				Collections.singletonList(edit));
+				Collections.singletonList(Either.<TextEdit, SnippetTextEdit>forLeft(edit)));
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		insertContentAction.setEdit(workspaceEdit);
 		return insertContentAction;
@@ -103,7 +104,7 @@ public class CodeActionFactory {
 				document.getUri(), document.getVersion());
 
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-				Collections.singletonList(edit));
+				Collections.singletonList(Either.<TextEdit, SnippetTextEdit>forLeft(edit)));
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		replaceContentAction.setEdit(workspaceEdit);
 		return replaceContentAction;

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: quarkus.jdt.ls Test Plugin
 Bundle-SymbolicName: org.eclipse.lsp4mp.jdt.test;singleton:=true
 Bundle-Version: 0.18.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-17
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.junit,
  org.apache.commons.commons-io,
  org.apache.commons.lang3,

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileForJavaAssert.java
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.test/src/main/java/org/eclipse/lsp4mp/jdt/core/MicroProfileForJavaAssert.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,6 +48,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -137,7 +139,11 @@ public class MicroProfileForJavaAssert {
 
 		VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(uri, 0);
 
-		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, Arrays.asList(te));
+		List<Either<TextEdit, SnippetTextEdit>> edits = new ArrayList<>();
+		for (TextEdit edit : te) {
+		    edits.add(Either.forLeft(edit));
+		}
+		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier, edits);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Arrays.asList(Either.forLeft(textDocumentEdit)));
 		codeAction.setEdit(workspaceEdit);
 		codeAction.setData(new CodeActionData(id));
@@ -226,11 +232,11 @@ public class MicroProfileForJavaAssert {
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
 		List<Diagnostic> received = actual;
 		final boolean filterMessage;
-		if (expected != null && !expected.isEmpty()
-				&& (expected.get(0).getMessage() == null || expected.get(0).getMessage().isEmpty())) {
-			filterMessage = true;
+		if (expected != null && !expected.isEmpty()) {
+		    Either<String, MarkupContent> message = expected.get(0).getMessage();
+		    filterMessage = message == null || (message.isLeft() && (message.getLeft() == null || message.getLeft().isEmpty()));
 		} else {
-			filterMessage = false;
+		    filterMessage = false;
 		}
 		if (filter) {
 			received = actual.stream().map(d -> {

--- a/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
+++ b/microprofile.jdt/org.eclipse.lsp4mp.jdt.tp/org.eclipse.lsp4mp.jdt.target
@@ -4,7 +4,7 @@
 	<locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/pom.xml
@@ -29,7 +29,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
-		<lsp4j.version>0.14.0</lsp4j.version>
+		<lsp4j.version>1.0.0</lsp4j.version>
 		<releases.repo.id>repo.eclipse.org</releases.repo.id>
 		<releases.repo.url>https://repo.eclipse.org/content/repositories/lsp4mp-releases/</releases.repo.url>
 		<snapshots.repo.id>repo.eclipse.org</snapshots.repo.id>
@@ -145,6 +145,16 @@
 			<groupId>io.smallrye.config</groupId>
 			<artifactId>smallrye-config</artifactId>
 			<version>3.14.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>33.6.0-jre</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.xbase.lib</artifactId>
+			<version>2.42.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/CodeActionFactory.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/ls/commons/CodeActionFactory.java
@@ -22,6 +22,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextEdit;
@@ -86,7 +87,7 @@ public class CodeActionFactory {
 				document.getUri(), document.getVersion());
 
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-				Collections.singletonList(edit));
+				Collections.singletonList(Either.<TextEdit, SnippetTextEdit>forLeft(edit)));
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		insertContentAction.setEdit(workspaceEdit);
 		return insertContentAction;
@@ -103,7 +104,7 @@ public class CodeActionFactory {
 				document.getUri(), document.getVersion());
 
 		TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-				Collections.singletonList(edit));
+				Collections.singletonList(Either.<TextEdit, SnippetTextEdit>forLeft(edit)));
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonList(Either.forLeft(textDocumentEdit)));
 		replaceContentAction.setEdit(workspaceEdit);
 		return replaceContentAction;

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileCodeActions.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/main/java/org/eclipse/lsp4mp/services/properties/PropertiesFileCodeActions.java
@@ -296,7 +296,7 @@ class PropertiesFileCodeActions {
 
 			for (int i = 0; i < requiredDiagnostics.size(); i++) {
 				Diagnostic diagnostic = requiredDiagnostics.get(i);
-				stringToInsert.append(getPropertyNameFromRequiredMessage(diagnostic.getMessage()));
+				stringToInsert.append(getPropertyNameFromRequiredMessage(diagnostic.getMessage().getLeft()));
 				stringToInsert.append(assign);
 
 				if (i < requiredDiagnostics.size() - 1) {

--- a/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
+++ b/microprofile.ls/org.eclipse.lsp4mp.ls/src/test/java/org/eclipse/lsp4mp/services/properties/PropertiesFileAssert.java
@@ -57,6 +57,7 @@ import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SnippetTextEdit;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.TextDocumentEdit;
@@ -748,7 +749,7 @@ public class PropertiesFileAssert {
 				return charCompare;
 			}
 			// If same position, compare by message to have stable ordering
-			return d1.getMessage().compareTo(d2.getMessage());
+			return d1.getMessage().getLeft().compareTo(d2.getMessage().getLeft());
 		};
 
 		sortedActual.sort(diagnosticComparator);
@@ -860,7 +861,7 @@ public class PropertiesFileAssert {
 			VersionedTextDocumentIdentifier versionedTextDocumentIdentifier = new VersionedTextDocumentIdentifier(
 					"microprofile-config.properties", 0);
 			TextDocumentEdit textDocumentEdit = new TextDocumentEdit(versionedTextDocumentIdentifier,
-					Collections.singletonList(te));
+					Collections.singletonList(Either.<TextEdit, SnippetTextEdit>forLeft(te)));
 			WorkspaceEdit workspaceEdit = new WorkspaceEdit(
 					Collections.singletonList(Either.forLeft(textDocumentEdit)));
 			codeAction.setEdit(workspaceEdit);


### PR DESCRIPTION
Updates lsp4mp to use JDT LS 1.60.0 and lsp4j 1.0.0, as requested in #549. This also means Java 21 is now required (JDT LS 1.60 needs it).
Some code had to be updated because lsp4j 1.0.0 changed a few of its APIs.